### PR TITLE
Issue053 intermediary initial step in reset

### DIFF
--- a/_class.py
+++ b/_class.py
@@ -96,7 +96,7 @@ class Solver():
             dparam=dparam, func_order=func_order, method=method,
         )
 
-        # store a simplified dict of variable arguments 
+        # store a simplified dict of variable arguments
         # used in reset() and run()
         lode = self.get_dparam(eqtype='ode', returnas=list)
         linter = self.__func_order
@@ -196,7 +196,6 @@ class Solver():
         # reset intermediary variables and auxiliary variables
         laux = self.get_dparam(eqtype='auxiliary', returnas=list)
         linter_aux = self.__func_order + laux
-        ii=0
         for k0 in linter_aux:
             # prepare dict of args
             kwdargs = {
@@ -275,7 +274,7 @@ class Solver():
             returnas=str,
         )
 
-    def get_summary(self,idx=0):
+    def get_summary(self, idx=0):
         """
         Print a str summary of the solver
 
@@ -317,7 +316,7 @@ class Solver():
             tuple([
                 k0,
                 v0['source'].split(':')[-1].replace('\n', '').replace(',', ''),
-                "{:.2e}".format(v0.get('value')[0,idx]),
+                "{:.2e}".format(v0.get('value')[0, idx]),
                 str(v0['units']),
                 v0['eqtype'].replace('intermediary', 'inter').replace(
                     'auxiliary', 'aux',
@@ -363,10 +362,10 @@ class Solver():
             end = '\n'
             flush = False
             timewait = False
-        elif type(verb) is float :  # if timewait is a float, then it is the
+        elif type(verb) is float:   # if timewait is a float, then it is the
             end = '\n'              # delta of real time between print
             flush = False
-            timewait = True         # will check real time between iterations      
+            timewait = True         # will check real time between iteratiions
         else:
             timewait = False
 
@@ -403,13 +402,13 @@ class Solver():
                         f'time step {ii+1} / {nt}'
                     )
                     print(msg, end=end, flush=flush)
-                if timewait :
-                    if time.time() - t0 > verb :
+                if timewait:
+                    if time.time() - t0 > verb:
                         msg = (
                             f'time step {ii+1} / {nt}'
                         )
                         print(msg, end=end, flush=flush)
-                        t0=time.time()
+                        t0 = time.time()
                     elif (ii == nt - 1 or ii == 1):
                         end = '\n'
                         msg = (
@@ -480,7 +479,6 @@ class Solver():
             dy3 = self.__dparam[k0]['func'](**kwdargs)
             dy4 = self.__dparam[k0]['func'](**kwdargs)
         return (dy1 + 2*dy2 + 2*dy3 + dy4) * self.__dparam['dt']['value']/6.
-
 
     # ##############################
     #       plotting methods

--- a/_class.py
+++ b/_class.py
@@ -199,7 +199,7 @@ class Solver():
         for k0 in linter_aux:
             # prepare dict of args
             kwdargs = {
-                k1: v1[ii, :]
+                k1: v1[0, :]
                 for k1, v1 in self.__dargs[k0].items()
             }
             # run function

--- a/utilities/_class_utility.py
+++ b/utilities/_class_utility.py
@@ -113,7 +113,7 @@ def _get_dict_subset(
         # return a copy of the dict
         return {k0: dict(indict[k0]) for k0 in lk}
     elif returnas is list:
-        # return only the keys 
+        # return only the keys
         return lk
 
     elif returnas in [np.ndarray, 'DataFrame']:

--- a/utilities/_class_utility.py
+++ b/utilities/_class_utility.py
@@ -45,6 +45,21 @@ def _get_dict_subset(
     if verb is None:
         verb = returnas is False
 
+    dreturn_ok = {
+        'False': False,
+        'dict': dict,
+        'np.ndarray': np.ndarray,
+        'list': list,
+        "'DataFrame'": 'DataFrame',
+    }
+    if returnas not in dreturn_ok.values():
+        lstr = [f'\t- {ss}' for ss in dreturn_ok.keys()]
+        msg = (
+            "Arg returnas must be in:\n"
+            + "\n".join(lstr)
+        )
+        raise Exception(msg)
+
     # ----------------------
     # select relevant parameters
 
@@ -97,6 +112,9 @@ def _get_dict_subset(
     if returnas is dict:
         # return a copy of the dict
         return {k0: dict(indict[k0]) for k0 in lk}
+    elif returnas is list:
+        # return only the keys 
+        return lk
 
     elif returnas in [np.ndarray, 'DataFrame']:
         out = {


### PR DESCRIPTION
Motivations:
----------------
* Introduction in issue #53 
* The idea of computing the first time step of all functions introduced by @DaluS in PR #50 is extended here, the associated function is incorporated into an section of `Solver.reset()`, as I assumed it would be logical and perhaps simpler for the user.
* As a result of this (pre-computing t`=0` for intermediary functions), the solving order for time step ii in run() has to be reversed: before it was intermediary then ode, now it must be ode then intermediary
* I also propose several minor changes and code clean-up, some of which result in a minor acceleration of the simulation time :-)

Main changes:
--------------------
* A few redundant lines removed in `Solver.__init__()`
* `Solver.runIntermediaryAtInitialState()` is deleted and the code is incorporated in `Solver.reset()`
* In `Solver.run()`, ode are now solved before intermediary
* In `Solver.run()`, there is now an option (compute_auxiliary) to activate / deactivate on-the-run computation of auxiliary functions (set to `True` by default, but that can be changed)
* Since now a computation of the dict of input `kwdargs` for each function is necessary both in `reset()` and in `run()`, I propose to compute this dictionary in `self.set_dparam()`, once and for all, as a hidden attribute. This way is called in `reset()` and `run()` instead of being re-created in each of them (faster, simpler, single-sourced). Also it now contains directly the values to be used and not just the keys.
* This it also allows the `lambda` exception to be dealt with there instead of dealing with it at every time step inside the time loop, which seems to result in a _non-negligibly faster run time_ :-)

Issues:
---------
* Fixes issue #53 

Results / examples:
--------------------------
* unit tests unchanged and passing
* user -interface unchanged (no new method, but all you wanted to do is done)
```
In [1]: import _class

In [2]: sol = _class.Solver('GK')
Suggested order for intermediary functions (func_order):
['Y', 'L', 'Pi', 'lambda', 'omega', 'phillips', 'kappa', 'I']
```

At this point the first time step of all functions has been computed
```
In [7]: sol.get_summary()
Numerical param.  value  units  comment                                        
----------------  -----  -----  -----------------------------------------------
Tmax              100    y      Duration of simulation                         
dt                0.01   y      Time step (fixed timestep method)              
nt                10000  None   Number of temporal iteration                   
nx                1      None   Number of similar systems evolving in parrallel

Model param.  value                  units   group       comment                                                    
------------  ---------------------  ------  ----------  -----------------------------------------------------------
r             0.03                   y^{-1}  Prices      Interest at the bank                                       
k0            -0.0065                None    Keen        Percent of GDP invested when profit is zero                
k1            0.006737946999085467   None    Keen        Investment slope                                           
k2            20                     None    Keen        Investment power in kappa                                  
alpha         0.02                   y^{-1}  Population  Rate of productivity increase                              
delta         0.005                  y^{-1}  Capital     Rate of capital depletion                                  
beta          0.025                  y^{-1}  Population  Rate of population growth                                  
nu            3                      None    Production  Kapital to output ratio                                    
phinull       0.04                   None    Philips     Unemployment rate that stops salary increase (no inflation)
phi0          0.04006410256410257    None    Philips                                                                
phi1          6.410256410256412e-05  None    Philips                                                                

function  source                         initial    units               eqtype  comment                                           
--------  -----------------------------  ---------  ------------------  ------  --------------------------------------------------
a          alpha * itself                1.00e+00   Output Humans^{-1}  ode     Exogenous technical progress as an exponential    
N          beta * itself                 1.00e+00   Humans              ode     Exogenous population as an exponential            
K          I - itself * delta            2.70e+00   Real Units          ode     Capital evolution from investment and depreciation
W          itself * phillips             8.50e-01   Dollars             ode     Wage evolution through phillips curve             
D          I - Pi                        1.00e-01   Dollars             ode     Debt as Investment-Profit difference              
Y          K / nu                        9.00e-01   Real units          inter   GDP in output quantity                            
L          K / (a * nu)                  9.00e-01   Humans              inter   Workers                                           
Pi         Y - W * L - r * D             1.32e-01   Dollars             inter   Absolute profit                                   
lambda     L / N                         9.00e-01                       inter   employment rate                                   
omega      W * L / Y                     8.50e-01                       inter   Wage share of the economy                         
phillips   -phi0 + phi1 / (1 - lamb)**2  -3.37e-02  y^{-1}              inter   Wage inflation rate                               
kappa      k0 + k1 * np.exp(k2*Pi/Y)     1.20e-01                       inter   Part of GDP in investment                         
I          Y * kappa                     1.08e-01   Dollars             inter   Investment                                        
g          (1 - omega) / nu - delta      4.50e-02   y^{-1}              aux     Relative growth                                   
d          D / Y                         1.11e-01                       aux     relative private debt                             
pi         1 - omega - r * d             1.47e-01                       aux     relative profit                                   
i          Y * 0                         0.00e+00   y^{-1}              aux     Inflation rate                                    
time       1.                            0.00e+00   y                   ode     Time vector          
```    

And are all re-computed using `sol.reset()`

The execution time of the simulation, which was, on my PC, around **1.30 seconds** in the previous version (see https://github.com/DaluS/GEMMES/pull/46#issuecomment-880465885), is now faster both with and without computing auxiliary functions on-the-run, with respectively a **20 %** and **28 %** gain:

```
In [5]: %timeit sol.run(compute_auxiliary=False)
time step 10000 / 10000
time step 10000 / 10000
time step 10000 / 10000
time step 10000 / 10000
time step 10000 / 10000
time step 10000 / 10000
time step 10000 / 10000
time step 10000 / 10000
931 ms ± 9.07 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [6]: %timeit sol.run(compute_auxiliary=True)
time step 10000 / 10000
time step 10000 / 10000
time step 10000 / 10000
time step 10000 / 10000
time step 10000 / 10000
time step 10000 / 10000
time step 10000 / 10000
time step 10000 / 10000
1.03 s ± 6.25 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```








