### PR TITLE
Issue055 additional solvers

### DIFF
--- a/_class.py
+++ b/_class.py
@@ -369,8 +369,6 @@ class Solver():
         # start time loop
         if timewait:
             t0 = time.time() # We look at the time between two iterations
-                                    # We removed 2 verb to be sure that we print
-
 
         if solver == 'eRK4-homemade':
 
@@ -404,13 +402,13 @@ class Solver():
                     break
 
                 # compute ode variables from ii-1, using solver
-                if solver == 'eRK4-homemade':
-                    _solvers._eRK4_homemade(
-                        dparam=self.__dparam,
-                        lode=lode,
-                        dargs=dargs,
-                        ii=ii,
-                    )
+                _solvers._eRK4_homemade(
+                    dparam=self.__dparam,
+                    lode=lode,
+                    dargs=dargs,
+                    ii=ii,
+                )
+
         elif solver == 'eRK4-scipy':
             sol = _solvers._eRK4_scipy(
                 dparam=self.__dparam,

--- a/_class.py
+++ b/_class.py
@@ -48,7 +48,7 @@ class Solver():
 
         # If all None => set to self._PARAMSET
         c0 = dparam is None and key is None and value is None
-        
+
         if c0 is True:
             print()
             dparam = self._MODEL
@@ -291,7 +291,7 @@ class Solver():
     # ##############################
     # run simulation
     # ##############################
-    def runIntermediaryAtInitialState(self): 
+    def runIntermediaryAtInitialState(self):
         """ Simply calculate each intermediary value at t=0
         """
         lode = list(self.get_dparam(eqtype='ode', returnas=dict).keys())
@@ -305,7 +305,7 @@ class Solver():
             for k0 in lode + linter + laux
         }
         ii=0
-        
+
         for k0 in linter:
             kwdargs = {
                 k1: self.__dparam[k1]['value'][ii, :]
@@ -321,7 +321,7 @@ class Solver():
             )
 
 
-    def run(self, verb=None):
+    def run(self, solver=None, verb=None):
         """ Run the simulation
 
         Compute each time step from the previous one using:
@@ -332,24 +332,10 @@ class Solver():
         """
         # ------------
         # check inputs
-        if verb in [None, True]:
-            verb = 1    
-            
-        if verb == 1:
-            end = '\r'
-            flush = True
-            timewait =False   
-        elif verb == 2:
-            end = '\n'
-            flush = False
-            timewait =False   
-        elif type(verb) is float : #if timewait is a float, then it is the
-            end = '\n'             # delta of real time between print
-            flush = False 
-            timewait =True         # we will check real time between iterations      
-        else : 
-            timewait = False
-            
+        verb, end, flush, timewait, solver = _class_checks._run_check(
+            verb=verb, solver=solver,
+        )
+
         # ------------
         # reset variables
         self.reset()
@@ -371,15 +357,15 @@ class Solver():
 
         # ------------
         # start time loop
-        if timewait : 
+        if timewait:
             t0 = time.time() # We look at the time between two iterations
                                     # We removed 2 verb to be sure that we print
                                     # the first iteration
-            
+
         for ii in range(nt):
             # log if verb > 0
             if verb > 0:
-                if not timewait : 
+                if not timewait:
                     if ii == nt - 1:
                         end = '\n'
                     msg = (

--- a/_core.py
+++ b/_core.py
@@ -389,7 +389,7 @@ class Solver():
         # ------------
         # start time loop
         if timewait:
-            t0 = time.time() # We look at the time between two iterations
+            t0 = time.time()    # We look at the time between two iterations
 
         if solver == 'eRK4-homemade':
 

--- a/_core.py
+++ b/_core.py
@@ -419,9 +419,9 @@ class Solver():
                 max_time_step=max_time_step,
                 solver_scipy=solver_scipy,
             )
-            self.sol = sol
 
         self.__run = True
+        self.__solver = solver
 
     # ##############################
     #       plotting methods

--- a/_core.py
+++ b/_core.py
@@ -191,7 +191,10 @@ class Solver():
 
         # reset ode variables
         for k0 in self.lfunc:
-            if self.__dparam[k0]['eqtype'] == 'ode':
+            if k0 == 'time':
+                self.__dparam[k0]['value'][0] = self.__dparam[k0]['initial']
+                self.__dparam[k0]['value'][1:] = np.nan
+            elif self.__dparam[k0]['eqtype'] == 'ode':
                 self.__dparam[k0]['value'][0, :] = self.__dparam[k0]['initial']
                 self.__dparam[k0]['value'][1:, :] = np.nan
             else:

--- a/_core.py
+++ b/_core.py
@@ -351,6 +351,7 @@ class Solver():
         verb=None,
         rtol=None,
         atol=None,
+        max_time_step=None,
     ):
         """ Run the simulation
 
@@ -389,59 +390,30 @@ class Solver():
 
         if solver == 'eRK4-homemade':
 
-            for ii in range(1, nt):
-
-                # print of wait
-                if verb > 0:
-                    _class_checks._print_or_wait(
-                        ii=ii, nt=nt, verb=verb,
-                        timewait=timewait, end=end, flush=flush,
-                    )
-                # compute ode variables from ii-1, using solver
-                _solvers._eRK4_homemade(
-                    dparam=self.__dparam,
-                    lode=lode,
-                    dargs=dargs,
-                    ii=ii,
-                )
-
-                # compute intermediary functions, in good order
-                # Now that inermediary functions are computed at t=0 in reset()
-                # we have to reverse the order of resolution:
-                # first ode then intermediary
-                for k0 in linter:
-                    kwdargs = {
-                        k1: v1[ii-1, :]
-                        for k1, v1 in self.__dargs[k0].items()
-                    }
-                    self.__dparam[k0]['value'][ii, :] = (
-                        self.__dparam[k0]['func'](
-                            **kwdargs,
-                        )
-                    )
-
-                # Since the computation is fast we can also compute auxiliary
-                if compute_auxiliary:
-                    for k0 in laux:
-                        kwdargs = {
-                            k1: v1[ii-1, :]
-                            for k1, v1 in self.__dargs[k0].items()
-                        }
-                        self.__dparam[k0]['value'][ii, :] = (
-                            self.__dparam[k0]['func'](
-                                **kwdargs
-                            )
-                        )
+            _solvers._eRK4_homemade(
+                dparam=self.__dparam,
+                lode=lode,
+                linter=linter,
+                laux=laux,
+                dargs=self.__dargs,
+                nt=nt,
+                verb=verb,
+                timewait=timewait,
+                end=end,
+                flush=flush,
+                compute_auxiliary=compute_auxiliary,
+            )
 
         elif solver == 'eRK4-scipy':
             sol = _solvers._eRK4_scipy(
                 dparam=self.__dparam,
                 lode=lode,
                 linter=linter,
-                dargs=dargs,
+                dargs=self.__dargs,
                 verb=verb,
                 rtol=rtol,
                 atol=atol,
+                max_time_step=max_time_step,
             )
             self.sol = sol
 

--- a/_core.py
+++ b/_core.py
@@ -365,7 +365,7 @@ class Solver():
         # check inputs
         (
             verb, end, flush, timewait,
-            compute_auxiliary, solver,
+            compute_auxiliary, solver, solver_scipy,
         ) = _class_checks._run_check(
             verb=verb, compute_auxiliary=compute_auxiliary, solver=solver,
         )
@@ -404,8 +404,8 @@ class Solver():
                 compute_auxiliary=compute_auxiliary,
             )
 
-        elif solver == 'eRK4-scipy':
-            sol = _solvers._eRK4_scipy(
+        elif 'scipy' in solver:
+            sol = _solvers._solver_scipy(
                 dparam=self.__dparam,
                 lode=lode,
                 linter=linter,
@@ -414,6 +414,7 @@ class Solver():
                 rtol=rtol,
                 atol=atol,
                 max_time_step=max_time_step,
+                solver_scipy=solver_scipy,
             )
             self.sol = sol
 

--- a/_core.py
+++ b/_core.py
@@ -362,7 +362,10 @@ class Solver():
         """
         # ------------
         # check inputs
-        verb, end, flush, timewait, solver = _class_checks._run_check(
+        (
+            verb, end, flush, timewait,
+            compute_auxiliary, solver,
+        ) = _class_checks._run_check(
             verb=verb, compute_auxiliary=compute_auxiliary, solver=solver,
         )
 
@@ -413,7 +416,8 @@ class Solver():
                     }
                     self.__dparam[k0]['value'][ii, :] = (
                         self.__dparam[k0]['func'](
-                            **kwdargs
+                            **kwdargs,
+                        )
                     )
 
                 # Since the computation is fast we can also compute auxiliary

--- a/models/_model_G_Reduced.py
+++ b/models/_model_G_Reduced.py
@@ -17,12 +17,15 @@ All parameters can have value:
 
 _FUNC_ORDER = None
 
-_DESCRIPTION = """ 
+_DESCRIPTION = """
     DESCRIPTION : This is the simplest economic post-keynesian model
-    TYPICAL BEHAVIOR : metastable oscillations around a solow point 
-    LINKTOARTICLE : Goodwin, Richard, 1967. ‘A growth cycle’, in: Carl Feinstein, editor, Socialism, capitalism,
-and economic growth. Cambridge, UK: Cambridge University Press.
+    TYPICAL BEHAVIOR : metastable oscillations around a solow point
+    LINKTOARTICLE : Goodwin, Richard, 1967. ‘A growth cycle’, in:
+        Carl Feinstein, editor, Socialism, capitalism
+        and economic growth. Cambridge, UK: Cambridge University Press.
         """
+
+
 # ---------------------------
 # user-defined model
 # contains parameters and functions of various types
@@ -76,26 +79,34 @@ _DPARAM = {
 # ---------------------------
 # List of presets for specific interesting simulations
 
-_PRESETS = { 
-    'smallcycle' : { 
-        'fields' : {
+_PRESETS = {
+    'smallcycle': {
+        'fields': {
             'lambda': .97,
-            'omega' : .85 ,   
-                    },
-        'com': 'This is a run that should give simple stable sinusoidal oscillations'
+            'omega': .85,
         },
-    'bigcycle' : { 
-        'fields' : {
+        'com': (
+            'This is a run that should give simple '
+            'stable sinusoidal oscillations'
+        ),
+    },
+    'bigcycle': {
+        'fields': {
             'lambda': .99,
-            'omega' : .85 ,   
-                    },
-        'com': 'This is a run that should give extremely violent stable oscillations'
-        },    
-        
-    'badnegociation' : {
-        'fields' : { 
+            'omega': .85,
+        },
+        'com': (
+            'This is a run that should give extremely '
+            'violent stable oscillations'
+        ),
+    },
+    'badnegociation': {
+        'fields': {
             'phinull': .3,
-                    },
-        'com': 'This should displace the Solow Point and allow big cycles with few harmonics'    
-                    },       
-    }
+        },
+        'com': (
+            'This should displace the Solow Point and '
+            'allow big cycles with few harmonics'
+        ),
+    },
+}

--- a/models/_model_G_Reduced.py
+++ b/models/_model_G_Reduced.py
@@ -49,7 +49,7 @@ _DPARAM = {
         'eqtype': 'ode',
         'initial': 0.85,
     },
-    
+
     # Intermediary
     'phillips': {
         'func': lambda phi0=0, phi1=0, lamb=0: -phi0 + phi1 / (1 - lamb)**2,

--- a/tests/test_01_Solver.py
+++ b/tests/test_01_Solver.py
@@ -54,7 +54,7 @@ class Test01_Run():
 
     @classmethod
     def setup_class(cls):
-        cls.dsolver = {}
+        cls.dmodel = {}
 
     @classmethod
     def setup(self):
@@ -73,29 +73,33 @@ class Test01_Run():
             returnas=list,
         )
         for model in lmodel:
-            self.dsolver[model] = _core.Solver(model)
+            self.dmodel[model] = _core.Solver(model)
 
     def test02_get_summary_repr(self):
-        for model in self.dsolver.keys():
-            print(self.dsolver[model])
-            self.dsolver[model].get_summary()
+        for model in self.dmodel.keys():
+            print(self.dmodel[model])
+            self.dmodel[model].get_summary()
 
     def test03_get_dparam(self):
-        for model in self.dsolver.keys():
-            out = self.dsolver[model].get_dparam(group='Numerical')
-            out = self.dsolver[model].get_dparam(eqtype='ode')
+        for model in self.dmodel.keys():
+            out = self.dmodel[model].get_dparam(group='Numerical')
+            out = self.dmodel[model].get_dparam(eqtype='ode')
 
     def test04_get_variables_compact(self):
-        for model in self.dsolver.keys():
-            out = self.dsolver[model].get_variables_compact()
+        for model in self.dmodel.keys():
+            out = self.dmodel[model].get_variables_compact()
 
     def test05_set_single_param(self):
-        for model in self.dsolver.keys():
-            self.dsolver[model].set_dparam(key='Tmax', value=20)
+        for model in self.dmodel.keys():
+            self.dmodel[model].set_dparam(key='Tmax', value=20)
 
-    def test06_run_all_models(self):
+    def test06_run_all_models_all_solvers(self):
         """ Make sure the main function runs as executable from terminal """
 
+        # solvers to be tested
+        lsolvers = ['eRK4-homemade', 'eRK2-scipy', 'eRK4-scipy', 'eRK8-scipy']
+
         # list of entry parameters to try
-        for model in self.dsolver.keys():
-            self.dsolver[model].run()
+        for model in self.dmodel.keys():
+            for solver in lsolvers:
+                self.dmodel[model].run(solver=solver)

--- a/utilities/_class_checks.py
+++ b/utilities/_class_checks.py
@@ -613,10 +613,51 @@ def _run_check(
     # -------
     # solver
 
-    dsolver_ok = {}
+    dsolver_ok = {
+        'eRK4-homemade': 'a home-made RK4 explicit solver',
+        'eRK4-scipy': 'the scipy RK4 explicit solver',
+        'eRK8-scipy': 'the scipy RK8 explicit solver',
+    }
     if solver is None:
         solver = 'eRK4-homemade'
-
+    if solver not in dsolver_ok.keys():
+        lstr = [f"\t- {k0}: {v0}" for k0, v0 in dsolver_ok.items()]
+        msg = (
+            "Arg solver is invalid, must be either:\n"
+            + "\n".join(lstr)
+        )
+        raise Exception(msg)
 
     return verb, end, flush, timewait, solver
 
+
+def _print_or_wait(
+    ii=None,
+    nt=None,
+    verb=None,
+    timewait=None,
+    end=None,
+    flush=None,
+):
+
+    if not timewait:
+        if ii == nt - 1:
+            end = '\n'
+        msg = (
+            f'time step {ii+1} / {nt}'
+        )
+        print(msg, end=end, flush=flush)
+
+    else:
+        if time.time()-t0 > verb:
+            msg = (
+                f'time step {ii+1} / {nt}'
+            )
+            print(msg, end=end, flush=flush)
+            t0 = time.time()
+        elif (ii == nt - 1 or ii == 0):
+            end = '\n'
+            msg = (
+                f'time step {ii+1} / {nt}'
+            )
+            print(msg, end=end, flush=flush)

--- a/utilities/_class_checks.py
+++ b/utilities/_class_checks.py
@@ -591,6 +591,7 @@ def _suggest_funct_order(
 
 
 def _run_check(
+    compute_auxiliary=None,
     solver=None,
     verb=None,
 ):
@@ -615,6 +616,11 @@ def _run_check(
     else:
         timewait = False
 
+    # ------------
+    # compute auxiliary
+    if compute_auxiliary is None:
+        compute_auxiliary = True
+
     # -------
     # solver
 
@@ -633,7 +639,7 @@ def _run_check(
         )
         raise Exception(msg)
 
-    return verb, end, flush, timewait, solver
+    return verb, end, flush, timewait, compute_auxiliary, solver
 
 
 def _print_or_wait(

--- a/utilities/_class_checks.py
+++ b/utilities/_class_checks.py
@@ -624,22 +624,38 @@ def _run_check(
     # -------
     # solver
 
-    dsolver_ok = {
-        'eRK4-homemade': 'a home-made RK4 explicit solver',
-        'eRK4-scipy': 'the scipy RK4 explicit solver',
-        'eRK8-scipy': 'the scipy RK8 explicit solver',
+    dsolver = {
+        'eRK4-homemade': {
+            'com': 'explicit Runge_Kutta order 4 homemade',
+        },
+        'eRK2-scipy': {
+            'scipy': 'RK23',
+            'com': 'explicit Runge_Kutta order 2 from scipy',
+        },
+        'eRK4-scipy': {
+            'scipy': 'RK45',
+            'com': 'explicit Runge_Kutta order 4 from scipy',
+        },
+        'eRK8-scipy': {
+            'scipy': 'DOP853',
+            'com': 'explicit Runge_Kutta order 8 from scipy',
+        },
     }
     if solver is None:
         solver = 'eRK4-homemade'
-    if solver not in dsolver_ok.keys():
-        lstr = [f"\t- {k0}: {v0}" for k0, v0 in dsolver_ok.items()]
+    if solver not in dsolver.keys():
+        lstr = [f"\t- '{k0}': {v0['com']}" for k0, v0 in dsolver.items()]
         msg = (
-            "Arg solver is invalid, must be either:\n"
+            "Arg solver must be in:\n"
             + "\n".join(lstr)
         )
         raise Exception(msg)
 
-    return verb, end, flush, timewait, compute_auxiliary, solver
+    solver_scipy = None
+    if 'scipy' in solver:
+        solver_scipy = dsolver[solver]['scipy']
+
+    return verb, end, flush, timewait, compute_auxiliary, solver, solver_scipy
 
 
 def _print_or_wait(

--- a/utilities/_class_checks.py
+++ b/utilities/_class_checks.py
@@ -611,7 +611,7 @@ def _run_check(
     elif type(verb) is float:   # if timewait is a float, then it is the
         end = '\n'              # delta of real time between print
         flush = False
-        timewait = True         # we will check real time between iterations      
+        timewait = True         # we will check real time between iterations
     else:
         timewait = False
 

--- a/utilities/_class_checks.py
+++ b/utilities/_class_checks.py
@@ -43,7 +43,6 @@ def _check_dparam(dparam=None):
 
     """
 
-
     # check type
     if not isinstance(dparam, dict):
         msg = (
@@ -604,15 +603,15 @@ def _run_check(
     if verb == 1:
         end = '\r'
         flush = True
-        timewait =False
+        timewait = False
     elif verb == 2:
         end = '\n'
         flush = False
-        timewait =False
-    elif type(verb) is float : #if timewait is a float, then it is the
-        end = '\n'             # delta of real time between print
+        timewait = False
+    elif type(verb) is float:   # if timewait is a float, then it is the
+        end = '\n'              # delta of real time between print
         flush = False
-        timewait =True         # we will check real time between iterations      
+        timewait = True         # we will check real time between iterations      
     else:
         timewait = False
 
@@ -676,7 +675,7 @@ def _print_or_wait(
         print(msg, end=end, flush=flush)
 
     else:
-        if time.time()-t0 > verb:
+        if time.time() - t0 > verb:
             msg = (
                 f'time step {ii+1} / {nt}'
             )

--- a/utilities/_class_checks.py
+++ b/utilities/_class_checks.py
@@ -577,3 +577,46 @@ def _suggest_funct_order(
     print(msg)
 
     return func_order
+
+
+# #############################################################################
+# #############################################################################
+#                       run checks
+# #############################################################################
+
+
+def _run_check(
+    solver=None,
+    verb=None,
+):
+    # ------
+    # verb
+
+    if verb in [None, True]:
+        verb = 1
+
+    if verb == 1:
+        end = '\r'
+        flush = True
+        timewait =False
+    elif verb == 2:
+        end = '\n'
+        flush = False
+        timewait =False
+    elif type(verb) is float : #if timewait is a float, then it is the
+        end = '\n'             # delta of real time between print
+        flush = False
+        timewait =True         # we will check real time between iterations      
+    else:
+        timewait = False
+
+    # -------
+    # solver
+
+    dsolver_ok = {}
+    if solver is None:
+        solver = 'eRK4-homemade'
+
+
+    return verb, end, flush, timewait, solver
+

--- a/utilities/_class_checks.py
+++ b/utilities/_class_checks.py
@@ -201,6 +201,11 @@ def check_dparam(dparam=None, func_order=None, method=None):
         method=method,
     )
 
+    # Make sure to copy to avoid passing by reference
+    dparam = {
+        k0: dict(v0) for k0, v0 in dparam.items()
+    }
+
     return dparam, model, func_order
 
 

--- a/utilities/_solvers.py
+++ b/utilities/_solvers.py
@@ -110,7 +110,7 @@ def _rk4(dparam=None, k0=None, y=None, kwdargs=None):
 # #############################################################################
 
 
-def _eRK4_scipy(
+def _solver_scipy(
     dparam=None,
     lode=None,
     linter=None,
@@ -119,6 +119,7 @@ def _eRK4_scipy(
     rtol=None,
     verb=None,
     max_time_step=None,
+    solver_scipy=None,
 ):
     """ scipy.RK45 solver, for cross-checking
 
@@ -139,19 +140,6 @@ def _eRK4_scipy(
         atol = 1.e-6
     if max_time_step is None:
         max_time_step = 10.*dparam['dt']['value']
-
-    # scipy compatibility
-    dsol_scipy = {
-        'eRK4-scipy': 'RK45',
-        'eRK8-scipy': 'RK89',
-    }
-    if solver not in dsol_scipy.keys():
-        lstr = [f"\t- '{k0}': '{v0}' (scipy)" for k0, v0 in dsol_scipy.items()]
-        msg = (
-            "Arg solver must be in:\n"
-            + "\n".join(lstr)
-        )
-        raise Exception(msg)
 
     # -----------------
     # define y0
@@ -217,7 +205,7 @@ def _eRK4_scipy(
         func,
         t_span,
         y0,
-        method=dsol_scipy[solver],
+        method=solver_scipy,
         t_eval=t_eval,
         max_step=max_time_step,
         rtol=rtol,

--- a/utilities/_solvers.py
+++ b/utilities/_solvers.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+
+import scipy.integrate as scpinteg
+
+
+# #############################################################################
+# #############################################################################
+#                   Home-made
+# #############################################################################
+
+
+def _eRK4_homemade(
+    dparam=None,
+    lode=None,
+    dargs=None,
+    ii=None,
+):
+    for k0 in lode:
+        kwdargs = {
+            k1: dparam[k1]['value'][ii, :] for k1 in dargs[k0]
+        }
+        if 'lambda' in dargs[k0]:
+            kwdargs['lamb'] = kwdargs['lambda']
+            del kwdargs['lambda']
+
+        dparam[k0]['value'][ii+1, :] = (
+            dparam[k0]['value'][ii, :]
+            + _rk4(
+                dparam=dparam,
+                k0=k0,
+                y=dparam[k0]['value'][ii, :],
+                kwdargs=kwdargs,
+            )
+        )
+
+
+def _rk4(dparam=None, k0=None, y=None, kwdargs=None):
+    """
+    a traditional RK4 scheme, with:
+        - y = array of all variables
+        - p = parameter dictionnary
+    dt is contained within p
+    """
+    if 'itself' in dparam[k0]['kargs']:
+        dy1 = dparam[k0]['func'](itself=y, **kwdargs)
+        dy2 = dparam[k0]['func'](itself=y+dy1/2., **kwdargs)
+        dy3 = dparam[k0]['func'](itself=y+dy2/2., **kwdargs)
+        dy4 = dparam[k0]['func'](itself=y+dy3, **kwdargs)
+    else:
+        dy1 = dparam[k0]['func'](**kwdargs)
+        dy2 = dparam[k0]['func'](**kwdargs)
+        dy3 = dparam[k0]['func'](**kwdargs)
+        dy4 = dparam[k0]['func'](**kwdargs)
+    return (dy1 + 2*dy2 + 2*dy3 + dy4) * dparam['dt']['value']/6.
+
+
+# #############################################################################
+# #############################################################################
+#                   scipy
+# #############################################################################
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/utilities/_solvers.py
+++ b/utilities/_solvers.py
@@ -157,7 +157,7 @@ def _eRK4_scipy(
         y0,
         method='RK45',
         t_eval=np.linspace(t_span[0], t_span[1], dparam['nt']['value']),
-        max_step=10.*dparam['dt']['value'],
+        max_step=2.*dparam['dt']['value'],
         rtol=rtol,
         atol=atol,
         vectorized=False,

--- a/utilities/_solvers.py
+++ b/utilities/_solvers.py
@@ -140,6 +140,19 @@ def _eRK4_scipy(
     if max_time_step is None:
         max_time_step = 10.*dparam['dt']['value']
 
+    # scipy compatibility
+    dsol_scipy = {
+        'eRK4-scipy': 'RK45',
+        'eRK8-scipy': 'RK89',
+    }
+    if solver not in dsol_scipy.keys():
+        lstr = [f"\t- '{k0}': '{v0}' (scipy)" for k0, v0 in dsol_scipy.items()]
+        msg = (
+            "Arg solver must be in:\n"
+            + "\n".join(lstr)
+        )
+        raise Exception(msg)
+
     # -----------------
     # define y0
 
@@ -204,7 +217,7 @@ def _eRK4_scipy(
         func,
         t_span,
         y0,
-        method='RK45',
+        method=dsol_scipy[solver],
         t_eval=t_eval,
         max_step=max_time_step,
         rtol=rtol,

--- a/utilities/_solvers.py
+++ b/utilities/_solvers.py
@@ -8,7 +8,6 @@ import scipy.integrate as scpinteg
 from . import _class_checks
 
 
-
 # #############################################################################
 # #############################################################################
 #                   Home-made
@@ -139,7 +138,7 @@ def _solver_scipy(
     if atol is None:
         atol = 1.e-6
     if max_time_step is None:
-        max_time_step = 10.*dparam['dt']['value']
+        max_time_step = 10. * dparam['dt']['value']
 
     if dparam['nx']['value'] > 1:
         msg = (
@@ -153,6 +152,7 @@ def _solver_scipy(
     # define f(t, y) (using pre-allocated array for speed
 
     dydt = np.full((len(lode_notime,)), np.nan)
+
     def func(t, y, dydt=dydt, dparam=dparam, lode_notime=lode_notime):
         """ dydt = f(t, y)
 

--- a/utilities/_solvers.py
+++ b/utilities/_solvers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+import numpy as np
 import scipy.integrate as scpinteg
 
 
@@ -61,16 +62,123 @@ def _rk4(dparam=None, k0=None, y=None, kwdargs=None):
 # #############################################################################
 
 
+def _eRK4_scipy(
+    dparam=None,
+    lode=None,
+    linter=None,
+    dargs=None,
+    atol=None,
+    rtol=None,
+    verb=None,
+):
+    """ scipy.RK45 solver, for cross-checking
+
+    First try: with a unique system (nx = 1)
+
+    issue: how do we update intermediary functions?
+    alogorithm only seems to allow ode...
+
+    Beware: here variable time steps are possible and should be handled
+
+    """
+
+    # -----------------
+    # check inputs
+    if rtol is None:
+        rtol = 1.e-3
+    if atol is None:
+        atol = 1.e-6
+
+    # -----------------
+    # define y0
+
+    y0 = np.array([
+        dparam[k0]['value'][0, 0] for k0 in lode
+    ])
+
+    # -----------------
+    # define f(t, y) (using pre-allocated array for speed
+
+    dydt = np.full((len(lode,)), np.nan)
+    def func(t, y, dydt=dydt, dparam=dparam):
+        """ dydt = f(t, y)
+
+        Where y is a (n,) array
+        y[0] = fisrt ode
+        y[1] = second ode
+        ...
+        y[n] = last ode
+
+        """
+
+        # ------------
+        # First update intermediary functions bqsed on provided y
+        for ii, k0 in enumerate(linter):
+            kwdargs = {
+                k1: dparam[k1]['value'][0, 0] for k1 in dargs[k0]
+            }
+            if 'lambda' in dargs[k0]:
+                kwdargs['lamb'] = kwdargs['lambda']
+                del kwdargs['lambda']
+
+            dparam[k0]['value'][0, 0] = dparam[k0]['func'](**kwdargs)
 
 
+        # ------------
+        # Then compute derivative functions (ode)
 
+        for ii, k0 in enumerate(lode):
+            kwdargs = {
+                k1: dparam[k1]['value'][0, 0]
+                for k1 in dargs[k0]
+                if k1 in linter
+            }
+            kwdargs.update({
+                k1: y[lode.index(k1)]
+                for k1 in dargs[k0]
+                if k1 in lode
+            })
+            if 'lambda' in dargs[k0]:
+                kwdargs['lamb'] = kwdargs['lambda']
+                del kwdargs['lambda']
 
+            if 'itself' in dparam[k0]['kargs']:
+                dydt[ii] = dparam[k0]['func'](itself=y[ii], **kwdargs)
+            else:
+                dydt[ii] = dparam[k0]['func'](**kwdargs)
 
+        return dydt
 
+    t_span = [dparam['time']['initial'], dparam['Tmax']['value']]
 
+    sol = scpinteg.solve_ivp(
+        func,
+        t_span,
+        y0,
+        method='RK45',
+        t_eval=np.linspace(t_span[0], t_span[1], dparam['nt']['value']),
+        max_step=10.*dparam['dt']['value'],
+        rtol=rtol,
+        atol=atol,
+        vectorized=False,
+        first_step=dparam['dt']['value'],
+    )
 
+    # ----------------
+    # verbosity
+    if verb > 0:
+        msg = (
+            f"{sol.message}\nSuccess: {sol.success}"
+        )
+        print(msg)
 
+    # ---------------------
+    # dispatch results
 
+    dparam['time']['value'] = sol.t
+    for ii, k0 in enumerate(lode):
+        if k0 == 'time':
+            continue
+        dparam[k0]['value'][:, 0] = sol.y[ii, :]
 
-
-
+    return sol


### PR DESCRIPTION
Motivation:
--------------
* In order to cross-check the simulations between different solvers
* In order to give the user a possibility of estimating the numerical uncertainty
* In order to have tools to cross-check / debug our own home-made debugger with more standard tools

Main changes:
--------------------
* All solvers are now in a dedicated `utilities/_solvers.py` file 
* Solver.run(solver=...) now offers the possibility of choosing between 4 solvers:
    - `'eRK4-homemade'`: an explicit Runge-Kutta 4 homemade solver
    - `'eRK2-scipy'`: an explicit Runge-Kutta 2 solver from scipy
    - `'eRK4-scipy'`: an explicit Runge-Kutta 4 solver from scipy
    - `'eRK8-scipy'`: an explicit Runge-Kutta 8 solver from scipy
* A few other options to parameteriize the scipy solvers are available (absolute and relative tolerance for convergence `atol` and `rtol`, and the maximum time step size `max_time_step`).
* The units tests have been updated to test all solvers for all available models.
* The unit tests check that the solver run without throwing an exception, but they don't (yet) compare the results computed by all solvers for a given model (will be done later)
* All unit tests passing

Issues:
----------
* Fixes issue #55 
* In terms of results, a clear difference appears between the 3 groups: 
    - homemade solver 
    - scipy RK2 and RK4
    - scipy RK8
 These 3 groups of solvers correspond to 3 different behaviours in terms of numerical results
=> No that we have implemented them (they are working and are usable), we can open a issue dedicated to understanding their differences in behaviour, and solving it if possible.
=> opening issue #58 

Example:
-------------
Using model `G_Reduced` to visualize the stationary oscillations (`lambda = 0.97`), and comparing the results of all solvers

```
In [1]: import _core

In [2]: solH = _core.Solver('G_Reduced')
Suggested order for intermediary functions (func_order):
['pi', 'phillips', 'g']

In [3]: sol2 = _core.Solver('G_Reduced')
Suggested order for intermediary functions (func_order):
['pi', 'phillips', 'g']

In [4]: sol4 = _core.Solver('G_Reduced')
Suggested order for intermediary functions (func_order):
['pi', 'phillips', 'g']

In [5]: sol8 = _core.Solver('G_Reduced')
Suggested order for intermediary functions (func_order):
['pi', 'phillips', 'g']

In [6]: solH.run()
time step 10000 / 10000

In [7]: sol2.run(solver='eRK2-scipy')
The solver successfully reached the end of the integration interval.
Success: True
Nb. fev: 3004 for 10000 time steps (0.3004 per time step)

In [8]: sol4.run(solver='eRK4-scipy')
The solver successfully reached the end of the integration interval.
Success: True
Nb. fev: 6007 for 10000 time steps (0.6007 per time step)

In [9]: sol8.run(solver='eRK8-scipy')
The solver successfully reached the end of the integration interval.
Success: True
Nb. fev: 15016 for 10000 time steps (1.5016 per time step)

In [11]: k0 = 'lambda'

In [12]: plt.figure(); plt.plot(solH.get_dparam(returnas=dict)['time']['value'], solH.get_dparam(returnas=dict)[k0]['value'], '-k', label='homemade'); plt.plot(sol2.get_dparam(returnas=dict)['time']['value'
    ...: ], sol2.get_dparam(returnas=dict)[k0]['value'], '.r', label='scipy RK2'); plt.plot(sol4.get_dparam(returnas=dict)['time']['value'], sol4.get_dparam(returnas=dict)[k0]['value'], '.b', label='scipy R
    ...: K4'); plt.plot(sol8.get_dparam(returnas=dict)['time']['value'], sol8.get_dparam(returnas=dict)[k0]['value'], '.g', label='scipy RK8'); plt.legend(); plt.gca().axhline(0.97, c='k', ls='--'); plt.gca
    ...: ().axhline(0.94675, c='k', ls='--');
```

![image](https://user-images.githubusercontent.com/5929562/126490471-25b3b69a-c9e9-49f3-8a99-d9488c69799c.png)

