### PR TITLE
Issue060 verb0

### DIFF
--- a/tests/test_01_Solver.py
+++ b/tests/test_01_Solver.py
@@ -107,9 +107,17 @@ class Test01_Run():
         lsolvers = ['eRK4-homemade', 'eRK2-scipy', 'eRK4-scipy', 'eRK8-scipy']
 
         # list of entry parameters to try
-        for model in self.dmodel.keys():
-            for solver in lsolvers:
-                self.dmodel[model].run(solver=solver)
+        for ii, model in enumerate(self.dmodel.keys()):
+            for jj, solver in enumerate(lsolvers):
+
+                if ii % 2 == 0:
+                    # testing verb = 0, 1, 2
+                    verb = (ii + jj) % 3
+                else:
+                    # testing verb = float
+                    verb = ii + jj/len(lsolvers)
+
+                self.dmodel[model].run(solver=solver, verb=verb)
 
     def test07_save(self):
         # list of entry parameters to try

--- a/tests/test_01_Solver.py
+++ b/tests/test_01_Solver.py
@@ -115,7 +115,7 @@ class Test01_Run():
                     verb = (ii + jj) % 3
                 else:
                     # testing verb = float
-                    verb = ii + jj/len(lsolvers)
+                    verb = ii + jj / len(lsolvers)
 
                 self.dmodel[model].run(solver=solver, verb=verb)
 

--- a/utilities/_class_checks.py
+++ b/utilities/_class_checks.py
@@ -644,6 +644,7 @@ def _run_check(
     if verb in [None, True]:
         verb = 1
 
+    end, flush, timewait = None, None, None
     if verb == 1:
         end = '\r'
         flush = True


### PR DESCRIPTION
Motivation:
-------------
* It was reported in issue #60  that the `Solver.run()` method was failing with `verb=0`
* This PR fixes it and also implement **_updated unit tests_** to make sure it is tested and does not happen again

Main changes:
----------------
* The issue came from the fact that `end`, `flush` and `timewait` were not defined in `utilities/_class_checks._run_check()` when `verb = 0` (because they were defined inside the `if` statement that start from `verb = 1`).
* They are now defined ahead of the `if` statement (set to `None` because they are not used when `verb = 0`)
* When such a bug is identified, it means the unit tests were not complete enough because they did not detect it earlier
=> It is then good practice to update the unit tests to make sure they would detect it if it happened again
=> The unit tests are updated to test all possible values of `verb`

Issues:
-------
* This fixes issue #60 

Example:
----------

```
In [1]: import _core                                                                                                                                

In [2]: sol = _core.Solver('G_Reduced')                                                                                                             
Suggested order for intermediary functions (func_order):
['pi', 'phillips', 'g']

In [3]: sol.run(verb=0)       

In [4]:
```