### PR TITLE
Issue84 all var mis behaves

### DIFF
--- a/_plots.py
+++ b/_plots.py
@@ -12,7 +12,7 @@ from matplotlib.collections import LineCollection
 import matplotlib.gridspec as gridspec
 
 
-def AllVar(sol, nrows=1, idx=0, dmargin=None, show=None):
+def AllVar(sol, ncols=1, idx=0, dmargin=Nonei, fs=None, show=None):
     '''
     Plot all the variables in the system on a same figure
 
@@ -20,10 +20,12 @@ def AllVar(sol, nrows=1, idx=0, dmargin=None, show=None):
     ----------
     sol : The hub of the system
         DESCRIPTION.
-    rows : the number of column on the plot
+    ncols : the number of column in the figure
         DESCRIPTION. The default is 2.
     idx : the index of the system you want to print
         DESCRIPTION. The default is 0.
+    dmargin: dict
+        dict defining the margins to be used for defining the axes
 
     Returns
     -------
@@ -39,6 +41,8 @@ def AllVar(sol, nrows=1, idx=0, dmargin=None, show=None):
             'bottom': 0.10, 'top': 0.90,
             'wspace': 0.10, 'hspace': 0.10,
         }
+    if fs is None:
+        fs = (20, 20)
     if show is None:
         show = True
 
@@ -51,10 +55,13 @@ def AllVar(sol, nrows=1, idx=0, dmargin=None, show=None):
 
     t = array[:, -1]
 
+    # derive nrows
+    nrows = len(lkeys) // ncols + 1
+
     # -----------
     # Prepare figure and axes
-    fig = plt.figure('All variables', figsize=(20, 20))
-    gs = gridspec.GridSpec(ncols=1, nrows=nrows, **dmargin)
+    fig = plt.figure('All variables', figsize=fs)
+    gs = gridspec.GridSpec(ncols=ncols, nrows=nrows, **dmargin)
 
     tit = f'{list(sol.model.keys())[0]} ||| system number: {idx}'
     fig.suptitle(tit)

--- a/_plots.py
+++ b/_plots.py
@@ -47,7 +47,7 @@ def AllVar(
     # Check inputs
 
     if ncols is None:
-        ncols = 2
+        ncols = 3
     if idx is None:
         idx = 0
     if dmargin is None:
@@ -72,9 +72,13 @@ def AllVar(
     # -----------
     # Prepare data to be plotted
 
-    lkeys, array = hub.get_variables_compact()
-    t = array[:, lkeys.tolist().index('time'), 0]
-    lkeys_notime = [kk for kk in lkeys if kk != 'time']
+    dpar = hub.get_dparam(returnas=dict)
+    t = dpar['time']['value'][:, idx]
+    lkeys_notime = [
+        k0 for k0, v0 in dpar.items()
+        if v0.get('func') is not None
+        and k0 != 'time'
+    ]
     nkeys = len(lkeys_notime)
 
     # derive nrows
@@ -102,16 +106,25 @@ def AllVar(
         if ii == 0 and sharex is True:
             shx = dax[key]
 
-        # set labels
-        dax[key].set_ylabel(key)
+        # set ylabels
+        if dpar[key]['symbol'] is None:
+            ylab = key
+        else:
+            ylab = dpar[key]['symbol']
+        if dpar[key]['units'] not in [None, '']:
+            ylab += f" ({dpar[key]['units']})"
+        dax[key].set_ylabel(ylab)
+
+        # set xlabel if at bottom
         if row == nrows - 1 or ii == nkeys - 1:
-            dax[key].set_xlabel('time (s)')
+            xlab = f"time ({dpar['time']['units']})"
+            dax[key].set_xlabel(xlab)
 
     # -----------
     # plot data on axes
 
     for ii, key in enumerate(lkeys_notime):
-        dax[key].plot(t, array[:, ii, idx])
+        dax[key].plot(t, dpar[key]['value'][:, idx])
 
     # -----------
     # show and return axes dict

--- a/_plots.py
+++ b/_plots.py
@@ -5,12 +5,14 @@ Created on Mon Jul 26 16:16:01 2021
 @author: Paul Valcke
 """
 
-import matplotlib.pyplot as plt
+
 import numpy as np
+import matplotlib.pyplot as plt
 from matplotlib.collections import LineCollection
+import matplotlib.gridspec as gridspec
 
 
-def AllVar(sol, rows=1, idx=0):
+def AllVar(sol, nrows=1, idx=0, dmargin=None, show=None):
     '''
     Plot all the variables in the system on a same figure
 
@@ -28,20 +30,47 @@ def AllVar(sol, rows=1, idx=0):
     None.
 
     '''
+
+    # -----------
+    # Check inputs
+    if dmargin is None:
+        dmargin = {
+            'left': 0.10, 'right': 0.90,
+            'bottom': 0.10, 'top': 0.90,
+            'wspace': 0.10, 'hspace': 0.10,
+        }
+    if show is None:
+        show = True
+
+
+    # -----------
+    # Prepare data to be printed
+
     # if sol.__dmisc['run']:
     lkeys, array = sol.get_variables_compact()
 
     t = array[:, -1]
-    plt.figure('All variables', figsize=(20, 20))
-    for i in range(len(lkeys) - 1):
+
+    # -----------
+    # Prepare figure and axes
+    fig = plt.figure('All variables', figsize=(20, 20))
+    gs = gridspec.GridSpec(ncols=1, nrows=nrows, **dmargin)
+
+    tit = f'{list(sol.model.keys())[0]} ||| system number: {idx}'
+    fig.suptitle(tit)
+
+    for ii in range(len(lkeys) - 1):
         lk = lkeys[i]
-        val = array[:, i, idx]
-        plt.subplot(len(lkeys) - 1, rows, i + 1)
+        val = array[:, ii, idx]
+        plt.subplot(len(lkeys) - 1, rows, ii + 1)
 
         plt.plot(t, val)
         plt.ylabel(lk)
-    plt.suptitle(list(sol.model.keys())[0] + '||| system number :' + str(idx))
-    plt.show()
+
+
+
+    if show is True
+        plt.show()
     # else:
     #    print('Plot simple could not be done as the simulation did not run')
 

--- a/tests/test_01_Hub.py
+++ b/tests/test_01_Hub.py
@@ -27,6 +27,7 @@ _PATH_OUTPUT_REF = os.path.join(_PATH_HERE, 'output_ref')
 # library-specific
 sys.path.insert(0, _PATH_PCK)   # ensure Main comes from .. => add PYTHONPATH
 import _core
+import _plots
 sys.path.pop(0)                 # clean PYTHONPATH
 
 
@@ -211,3 +212,14 @@ class Test01_Run():
                 + "\n".join(lstr)
             )
             raise Exception(msg)
+
+    def test13_plot_AllVar(self):
+        ii = 0
+        for model in self.dmodel.keys():
+            for solver in self.lsolvers:
+                dax = _plots.AllVar(
+                    self.dmodel[model][solver],
+                    ncols=1 + ii % 4,
+                )
+                ii += 1
+            plt.close('all')


### PR DESCRIPTION
Motivations:
----------------
* See issue #84 
* This PR is also a mini-tutorial on:
    - how to use `gridspec`
    - good practices for structuring a plotting method (the routine was already nicely structured, I just include this as general guidance for future contributors and just add a few tips):
        - check inputs
        - prepare data
        - prepare axes (and store them in a dict)
        - plot data
        - return the axes dict for later use from the command line
        - implement a unit test to test the routine

Main changes:
--------------------
* `rows` has been renamed to `ncols`
* user can now also choose the **_figure size_**, the _**margins**_, the figure _**title**_ and _**suptitle**_
* inputs are checked
* getting data from `hub.get_dparam()` instead of `hub.get_variables_compact()` because we also want the `symbol`, `units`...
* We use `gridspec` for fine and easy control of the axes layout
* the whole figure space is used whatever the number of columns (no blank spaces anymore)
* The `ylabels` now include the (latex) `symbol` and the `units`
* Axes are stored in a `dict`, which is returned (can be useful to modify the plot later from the command line)
* By default, all axes share the same x-axis (dynamically updated for all when zooming) using `sharex`, can be deactivated.
* A basic unit test has been implemented to check the routine is operational (passing)

Issues:
---------
* Fixes issue #84 

Examples:
--------------

```
In [1]: import _core, _plots

In [2]: hub = _core.Hub('GK')
Suggested order for intermediary functions (func_order):
['Y', 'L', 'Pi', 'lambda', 'omega', 'phillips', 'kappa', 'I']

In [3]: hub.run()

In [4]: dax = _plots.AllVar(hub)
```
![image](https://user-images.githubusercontent.com/5929562/129155933-7bf9cdb5-4e6c-4471-98d5-927071c5c3a7.png)


```
In [6]: dax = _plots.AllVar(hub, ncols=4, wintit='blabla', tit='test', fs=(12, 8))
```
![image](https://user-images.githubusercontent.com/5929562/129156011-bd4dde8e-994c-4dda-9ea7-8d283b8fd2dc.png)

Thanks to `sharex`, zooming on a few cycles of `lambda` automatically zooms on all axes simultaneously:

![image](https://user-images.githubusercontent.com/5929562/129157201-4e49fb9b-1d33-49d8-ade8-ab01f332c58b.png)


