### PR TITLE
Addition of Putty-Clay model and PDE support

### DIFF
--- a/_core.py
+++ b/_core.py
@@ -127,9 +127,6 @@ class Hub():
             'parameter', 'value', 'units', 'dimension', 'symbol',
             'type', 'eqtype', 'group', 'comment',
         ]
-        
-        if verb is None and returnas is None:
-            print("")
 
         return _class_utility._get_dict_subset(
             indict=self.__dparam,

--- a/_core.py
+++ b/_core.py
@@ -283,8 +283,8 @@ class Hub():
         """ This is automatically called when only the instance is entered """
         col0 = ['model', 'source', 'nb. model param', 'nb. functions', 'run']
         ar0 = [
-            list(self.__dmisc['model']['name'],
-            list(self.__dmisc['model']['file'],
+            self.__dmisc['model']['name'],
+            self.__dmisc['model']['file'],
             len([
                 k0 for k0, v0 in self.__dparam.items()
                 if v0.get('func') is None

--- a/_core.py
+++ b/_core.py
@@ -127,6 +127,9 @@ class Hub():
             'parameter', 'value', 'units', 'dimension', 'symbol',
             'type', 'eqtype', 'group', 'comment',
         ]
+        
+        if verb is None and returnas is None:
+            print("")
 
         return _class_utility._get_dict_subset(
             indict=self.__dparam,
@@ -305,7 +308,8 @@ class Hub():
 
         """
         value_str = (lambda value, fmt="{}":
-                         fmt.format(value) if np.isscalar(value) else "Array")
+                     fmt.format(value) if np.isscalar(value)
+                     else f"{value.shape} array")
 
         # ----------
         # Numerical parameters
@@ -435,7 +439,7 @@ class Hub():
                     and v0.get('func') is not None
                     and not np.isscalar(v0['value'][-1, idx])]
             if len(larr) > 0:
-                ps2 += ("\n"
+                ps2 += ("\n\n"
                         "Final array values:\n"
                         "------------------\n"
                         + '\n'.join(larr))

--- a/_core.py
+++ b/_core.py
@@ -286,8 +286,8 @@ class Hub():
         """ This is automatically called when only the instance is entered """
         col0 = ['model', 'source', 'nb. model param', 'nb. functions', 'run']
         ar0 = [
-            list(self.__dmisc['model'].keys())[0],
-            list(self.__dmisc['model'].values())[0],
+            list(self.__dmisc['model']['name'],
+            list(self.__dmisc['model']['file'],
             len([
                 k0 for k0, v0 in self.__dparam.items()
                 if v0.get('func') is None

--- a/_core.py
+++ b/_core.py
@@ -265,13 +265,13 @@ class Hub():
             for k0, v0 in self.__dparam.items()
             if v0.get('eqtype') in leqtype
         ])
-        
+
         # Get compact variable array
         variables = np.concatenate([
             v0['value'].reshape(sys_shape + [-1])
             for k0, v0 in self.__dparam.items()
             if v0.get('eqtype') in leqtype
-            ], axis=len(sys_shape))
+        ], axis=len(sys_shape))
 
         return keys, variables
 
@@ -305,7 +305,7 @@ class Hub():
 
         """
         value_str = (lambda value, fmt="{}":
-            fmt.format(value) if np.isscalar(value) else "Array")
+                         fmt.format(value) if np.isscalar(value) else "Array")
 
         # ----------
         # Numerical parameters

--- a/_core.py
+++ b/_core.py
@@ -195,7 +195,7 @@ class Hub():
                          else list(self.__dparam[k0]['initial'].shape))
             self.__dparam[k0]['value'] = np.full(sys_shape + var_shape, np.nan)
             self.__dparam[k0]['value'][0] = self.__dparam[k0]['initial']
-        
+
         # Add references in dict of arguments to newly initialized values
         # handling any lambda exception here rather than at each time step
         self.__dargs = {
@@ -258,14 +258,13 @@ class Hub():
         # Define shape of model system
         sys_shape = [self.__dparam['nt']['value'],
                      self.__dparam['nx']['value']]
-        
 
         # list of keys of variables
         keys = np.hstack([
-            np.repeat(k0, np.prod(v0['value'].shape[len(sys_shape):])) 
+            np.repeat(k0, np.prod(v0['value'].shape[len(sys_shape):]))
             for k0, v0 in self.__dparam.items()
             if v0.get('eqtype') in leqtype
-            ])
+        ])
         
         # Get compact variable array
         variables = np.concatenate([
@@ -307,7 +306,7 @@ class Hub():
         """
         value_str = (lambda value, fmt="{}":
             fmt.format(value) if np.isscalar(value) else "Array")
-            
+
         # ----------
         # Numerical parameters
         col0 = ['Numerical param.', 'value', 'units', 'comment']
@@ -321,7 +320,7 @@ class Hub():
             for k0, v0 in self.__dparam.items() if v0['group'] == 'Numerical'
         ]
         ar0.append(['run', str(self.__dmisc['run']), '', ''])
-        
+
         larr = [f"{k0}:\n"
                 f"    {v0['value']}" for k0, v0 in self.__dparam.items()
                 if v0['group'] == 'Numerical' and not np.isscalar(v0['value'])]
@@ -332,7 +331,6 @@ class Hub():
                    + '\n'.join(larr))
         else:
             ps0 = ""
-            
 
         # ----------
         # parameters
@@ -348,8 +346,8 @@ class Hub():
             for k0, v0 in self.__dparam.items()
             if v0['group'] != 'Numerical'
             and v0.get('func') is None
-        ]        
-        
+        ]
+
         larr = [f"{k0}:\n"
                 f"    {v0['value']}" for k0, v0 in self.__dparam.items()
                 if v0['group'] != 'Numerical'
@@ -382,14 +380,14 @@ class Hub():
             for k0, v0 in self.__dparam.items()
             if v0.get('func') is not None
         ]
-        
+
         lexp = [(f"def d_t {k0}:" if v0['eqtype'] == 'ode' else
-                 f"def \partial_t {k0}:" if v0['eqtype'] == 'pde' else
+                 f"def \\partial_t {k0}:" if v0['eqtype'] == 'pde' else
                  f"def {k0}:")
-                 + v0['source_exp']
-                 for k0, v0 in self.__dparam.items()
-                 if v0.get('func') is not None
-                 and 'return' in v0['source_exp']]
+                + v0['source_exp']
+                for k0, v0 in self.__dparam.items()
+                if v0.get('func') is not None
+                and 'return' in v0['source_exp']]
         if len(lexp) > 0:
             ps2 = ("\n\n"
                    "Multi-line functions:\n"
@@ -428,7 +426,7 @@ class Hub():
                         value_str(v0.get('value')[-1, idx], fmt="{:.2e}"),
                     )
                     ii += 1
-                    
+
             # add final values to postscript
             larr = [f"{k0}:\n"
                     f"    {v0['value'][0, idx]}"

--- a/_plots.py
+++ b/_plots.py
@@ -98,8 +98,8 @@ def Var(sol, key, idx=0, cycles=False, log=False):
 
     if log is True:
         ax.set_yscale('log')
-    plt.title("Evolution of {key} in model #{idx}"
-              + sol.model['name'] + '| system number' + str(idx))
+    plt.title(f"Evolution of {key} in model {sol.model['name']} | "
+              f"system number {idx}")
     plt.ylabel(key)
     plt.xlabel('time')
     plt.show()

--- a/_plots.py
+++ b/_plots.py
@@ -40,7 +40,7 @@ def AllVar(sol, rows=1, idx=0):
 
         plt.plot(t, val)
         plt.ylabel(lk)
-    plt.suptitle(list(sol.model.keys())[0] + '||| system number :' + str(idx))
+    plt.suptitle(sol.model['name'] + '||| system number :' + str(idx))
     plt.show()
     # else:
     #    print('Plot simple could not be done as the simulation did not run')
@@ -62,7 +62,7 @@ def Var(sol, key, idx=0, cycles=False, log=False):
     None.
 
     '''
-    plt.figure('key :' + key + '| system idx' + str(idx), figsize=(10, 5))
+    plt.figure(f"key : {key} | system idx : {idx}", figsize=(10, 5))
     fig = plt.gcf()
     ax = plt.gca()
 
@@ -98,8 +98,8 @@ def Var(sol, key, idx=0, cycles=False, log=False):
 
     if log is True:
         ax.set_yscale('log')
-    plt.title('Evolution of :' + key + ' in model : '
-              + list(sol.model.keys())[0] + '| system number' + str(idx))
+    plt.title("Evolution of {key} in model #{idx}"
+              + sol.model['name'] + '| system number' + str(idx))
     plt.ylabel(key)
     plt.xlabel('time')
     plt.show()
@@ -145,14 +145,14 @@ def phasespace(sol, x='omega', y='lambda', color='time', idx=0):
     plt.ylim([np.amin(yval), np.amax(yval)])
     plt.axis('scaled')
     plt.title('Phasespace ' + x + '-' + y + ' for model : '
-              + list(sol.model.keys())[0] + '| system number' + str(idx))
+              + sol.model['name'] + '| system number' + str(idx))
 
     plt.show()
 
 
 def AllPhaseSpace(sol, variablesREF, idx=0):
     plt.figure('All Phasespace for system :'+str(idx)+' for model : ' +
-               list(sol.model.keys())[0], figsize=(10, 7))
+               sol.model['name'], figsize=(10, 7))
     fig = plt.gcf()
     leng = len(variablesREF)
     NumbOfSubplot = int(leng*(leng-1)/2)
@@ -185,5 +185,5 @@ def AllPhaseSpace(sol, variablesREF, idx=0):
             idd += 1
     fig.colorbar(line, ax=ax, label='time')
     plt.suptitle('All Phasespace for system :'+str(idx)+' for model : ' +
-                 list(sol.model.keys())[0])
+                 sol.model['name'])
     plt.show()

--- a/models/_def_fields.py
+++ b/models/_def_fields.py
@@ -492,7 +492,7 @@ _DFIELDS = {
         'dimension': 'Real Units',
         'units': 'Real units yr^{-1}',
         'type': 'extensive',
-        'symbol': r'$yr$',
+        'symbol': r'$Y$',
         'group': 'Missing',
     },
     'L': {

--- a/models/_def_fields.py
+++ b/models/_def_fields.py
@@ -288,7 +288,7 @@ _DFIELDS = {
     # PUTTY-CLAY MODEL FOR CAPITAL INVESTMENT
     'kl_ratios': {
         'value': np.arange(100),
-        'com': 'Spread of investment around optimal capital-labor ratio',
+        'com': 'Possible capital-labor ratios',
         'dimension': 'Capital-labor ratio',
         'units': 'Dollars Humans^{-1}',
         'type': 'intensive',

--- a/models/_def_fields.py
+++ b/models/_def_fields.py
@@ -56,9 +56,9 @@ _DALLOWED_FIELDS = {
     'value': None,
     'com': None,
     'units': [
-        'Units',  #
-        'y',      # Time
-        '$',      # Money
+        'Real Units',  #
+        'yr',      # Time
+        'Dollars',      # Money
         'C',      # Concentration
         'Humans',  # Population
     ],
@@ -89,7 +89,7 @@ _DFIELDS = {
         'value': 100,
         'com': 'Duration of simulation',
         'dimension': 'time',
-        'units': 'y',
+        'units': 'yr',
         'type': None,
         'symbol': None,
         'group': 'Numerical',
@@ -98,7 +98,7 @@ _DFIELDS = {
         'value': 0.01,
         'com': 'Time step (fixed timestep method)',
         'dimension': 'time',
-        'units': 'y',
+        'units': 'yr',
         'type': None,
         'symbol': None,
         'group': 'Numerical',
@@ -130,12 +130,22 @@ _DFIELDS = {
         'func': lambda dt=0: 1.,
         'com': 'Time vector',
         'dimension': 'time',
-        'units': 'y',
+        'units': 'yr',
         'type': 'extensive',
         'symbol': r'$t$',
         'group': 'Time',
         'eqtype': 'ode',
         'initial': 0,
+    },
+    
+    'tau': {
+        'value': 1,
+        'com': 'Adjustment timescale',
+        'dimension': 'time',
+        'units': 'yr',
+        'type': 'intensive',
+        'symbol': r'$\tau$',
+        'group': 'Time',
     },
 
     # PARAMETERS #############################################################
@@ -146,7 +156,7 @@ _DFIELDS = {
         'value': 0.025,
         'com': 'Rate of population growth',
         'dimension': 'time rate',
-        'units': 'y^{-1}',
+        'units': 'yr^{-1}',
         'type': 'intensive',
         'symbol': r'$beta$',
         'group': 'Population',
@@ -155,7 +165,7 @@ _DFIELDS = {
         'value': 0.02,
         'com': 'Rate of productivity increase',
         'dimension': 'time rate',
-        'units': 'y^{-1}',
+        'units': 'yr^{-1}',
         'type': 'intensive',
         'symbol': r'$alpha$',
         'group': 'Population',
@@ -167,9 +177,27 @@ _DFIELDS = {
         'value': 0.005,
         'com': 'Rate of capital depletion',
         'dimension': 'time rate',
-        'units': 'y^{-1}',
+        'units': 'yr^{-1}',
         'type': 'intensive',
         'symbol': r'$\delta$',
+        'group': 'Capital',
+    },    
+    's_p': {
+        'value': 1,
+        'com': 'Proportion of profit invested in capital',
+        'dimension': '',
+        'units': '',
+        'type': 'intensive',
+        'symbol': r'$s_p$',
+        'group': 'Capital',
+    },
+    's_w': {
+        'value': 0,
+        'com': 'Proportion of wages invested in capital',
+        'dimension': '',
+        'units': '',
+        'type': 'intensive',
+        'symbol': r'$s_w$',
         'group': 'Capital',
     },
 
@@ -185,20 +213,18 @@ _DFIELDS = {
         'group': 'Production',
     },
 
-
     # --------------
     # INTEREST / Price
     'r': {
         'value': .03,
         'com': 'Interest at the bank',
         'dimension': 'time rate',
-        'units': 'y^{-1}',
+        'units': 'yr^{-1}',
         'type': 'intensive',
         'symbol': None,
         'group': 'Prices',
     },
-
-
+    
     # --------------
     # PHILIPS CURVE (employement-salary increase)
     'phinull': {
@@ -259,6 +285,72 @@ _DFIELDS = {
         'group': 'Keen',
     },
 
+    # --------------
+    # PUTTY-CLAY MODEL FOR CAPITAL INVESTMENT
+    'kl_ratios': {
+        'value': np.arange(100),
+        'com': 'Spread of investment around optimal capital-labor ratio',
+        'dimension': 'Capital-labor ratio',
+        'units': 'Dollars Humans^{-1}',
+        'type': 'intensive',
+        'symbol': r'$\sigma_{kl}$',
+        'group': 'Putty-Clay',
+    },    
+    'productivity_fn': {
+        'value': np.arange(100),
+        'com': 'Labor productivity as a function of capital-labor ratio',
+        'dimension': 'Labor productivity',
+        'units': 'Dollars Human^{-1} yr^{-1}',
+        'type': 'intensive',
+        'symbol': r'$f$',
+        'group': 'Production',
+    },
+    'labor_density': {
+        'value': np.zeros(100),
+        'com': 'Labor employable on machines of varying capital-labor ratio',
+        'dimension': 'Labor density',
+        'units': 'Humans^{2] Dollars^{-1}',
+        'type': 'extensive',
+        'symbol': r'$l$',
+        'group': 'Putty-Clay',
+    },
+    'id_kl_min': {
+        'value': 0,
+        'com': 'Minimum capital-labor ratio for operation',
+        'dimension': 'Capital-labor ratio',
+        'units': 'Dollars Humans^{-1}',
+        'type': 'intensive',
+        'symbol': r'$k_{min}$',
+        'group': 'Putty-Clay',
+    },
+    'kl_optimum': {
+        'value': 0,
+        'com': 'Profit-optimal capital-labor ratio',
+        'dimension': 'Capital-labor ratio',
+        'units': 'Dollars Humans^{-1}',
+        'type': 'intensive',
+        'symbol': r'$k_{opt}$',
+        'group': 'Putty-Clay',
+    },    
+    'kl_sigma': {
+        'value': 0.1,
+        'com': 'Spread of investment around optimal capital-labor ratio',
+        'dimension': 'Capital-labor ratio',
+        'units': 'Dollars Humans^{-1}',
+        'type': 'intensive',
+        'symbol': r'$\sigma_{kl}$',
+        'group': 'Putty-Clay',
+    },
+    'I_distribution': {
+        'value': np.ones(100),
+        'com': 'Distribution of investment around optimal capital-labor ratio',
+        'dimension': 'Labor-capital ratio',
+        'units': 'Humans Dollar^{-1}',
+        'type': 'intensive',
+        'symbol': r'$\delta_{D}$',
+        'group': 'Putty-Clay',
+    },
+
     # DYNAMICAL VARIABLES ####################################################
     # ------------------------------------------------------------------------
     # ------------------------------------------------------------------------
@@ -297,7 +389,7 @@ _DFIELDS = {
         'value': None,
         'com': 'productivity per worker',
         'dimension': 'Productivity',
-        'units': 'Output Humans^{-1}',
+        'units': 'Real Units Humans^{-1} yr^{-1}',
         'type': 'intensive',
         'symbol': r'$a$',
         'group': 'Economy',
@@ -326,7 +418,7 @@ _DFIELDS = {
         'value': None,
         'com': 'Salary',
         'dimension': 'Money',
-        'units': 'Dollars',
+        'units': 'Dollars Humans^{-1} yr^{-1}',
         'type': 'extensive',
         'symbol': r'$W$',
         'group': 'Economy',
@@ -359,7 +451,7 @@ _DFIELDS = {
         'value': None,
         'com': 'Wage inflation rate',
         'dimension': 'time rate',
-        'units': 'y^{-1}',
+        'units': 'yr^{-1}',
         'type': 'intensive',
         'symbol': r'$\phi$',
         'group': 'Economy',
@@ -380,7 +472,7 @@ _DFIELDS = {
         'value': None,
         'com': 'Relative growth',
         'dimension': 'time rate',
-        'units': 'y^{-1}',
+        'units': 'yr^{-1}',
         'type': 'intensive',
         'symbol': r'$g$',
         'group': 'Economy',
@@ -389,7 +481,7 @@ _DFIELDS = {
         'value': None,
         'com': 'GDP in nominal term',
         'dimension': 'Money',
-        'units': 'Dollars',
+        'units': 'Dollars yr^{-1}',
         'type': 'extensive',
         'symbol': r'$GDP$',
         'group': 'Economy',
@@ -398,9 +490,9 @@ _DFIELDS = {
         'value': None,
         'com': 'GDP in output quantity',
         'dimension': 'Real Units',
-        'units': 'Real units',
+        'units': 'Real units yr^{-1}',
         'type': 'extensive',
-        'symbol': r'$Y$',
+        'symbol': r'$yr$',
         'group': 'Missing',
     },
     'L': {
@@ -416,7 +508,7 @@ _DFIELDS = {
         'value': None,
         'com': 'Investment',
         'dimension': 'Money',
-        'units': 'Dollars',
+        'units': 'Dollars yr^{-1}',
         'type': 'extensive',
         'symbol': r'$I$',
         'group': 'Economy',
@@ -425,7 +517,7 @@ _DFIELDS = {
         'value': None,
         'com': 'Absolute profit',
         'dimension': 'Money',
-        'units': 'Dollars',
+        'units': 'Dollars yr^{-1}',
         'type': 'extensive',
         'symbol': r'$\Pi$',
         'group': 'Economy',
@@ -435,7 +527,7 @@ _DFIELDS = {
         'value': None,
         'com': 'Inflation rate',
         'dimension': 'time rate',
-        'units': 'y^{-1}',
+        'units': 'yr^{-1}',
         'type': 'intensive',
         'symbol': r'$i$',
         'group': 'Economy',

--- a/models/_def_fields.py
+++ b/models/_def_fields.py
@@ -335,8 +335,8 @@ _DFIELDS = {
     'kl_sigma': {
         'value': 0.1,
         'com': 'Spread of investment around optimal capital-labor ratio',
-        'dimension': 'Capital-labor ratio',
-        'units': 'Dollars Humans^{-1}',
+        'dimension': '',
+        'units': '',
         'type': 'intensive',
         'symbol': r'$\sigma_{kl}$',
         'group': 'Putty-Clay',
@@ -414,13 +414,13 @@ _DFIELDS = {
         'symbol': r'$K$',
         'group': 'Economy',
     },
-    'W': {
+    'w': {
         'value': None,
         'com': 'Salary',
         'dimension': 'Money',
         'units': 'Dollars Humans^{-1} yr^{-1}',
         'type': 'extensive',
-        'symbol': r'$W$',
+        'symbol': r'$w$',
         'group': 'Economy',
     },
     'D': {

--- a/models/_def_fields.py
+++ b/models/_def_fields.py
@@ -137,7 +137,6 @@ _DFIELDS = {
         'eqtype': 'ode',
         'initial': 0,
     },
-    
     'tau': {
         'value': 1,
         'com': 'Adjustment timescale',
@@ -181,7 +180,7 @@ _DFIELDS = {
         'type': 'intensive',
         'symbol': r'$\delta$',
         'group': 'Capital',
-    },    
+    },
     's_p': {
         'value': 1,
         'com': 'Proportion of profit invested in capital',
@@ -224,7 +223,7 @@ _DFIELDS = {
         'symbol': None,
         'group': 'Prices',
     },
-    
+
     # --------------
     # PHILIPS CURVE (employement-salary increase)
     'phinull': {
@@ -295,7 +294,7 @@ _DFIELDS = {
         'type': 'intensive',
         'symbol': r'$\sigma_{kl}$',
         'group': 'Putty-Clay',
-    },    
+    },
     'productivity_fn': {
         'value': np.arange(100),
         'com': 'Labor productivity as a function of capital-labor ratio',
@@ -331,7 +330,7 @@ _DFIELDS = {
         'type': 'intensive',
         'symbol': r'$k_{opt}$',
         'group': 'Putty-Clay',
-    },    
+    },
     'kl_sigma': {
         'value': 0.1,
         'com': 'Spread of investment around optimal capital-labor ratio',

--- a/models/_model_Putty-Clay_AS69.py
+++ b/models/_model_Putty-Clay_AS69.py
@@ -62,7 +62,7 @@ def lognormal_distribution(kl_optimum=1, kl_sigma=1,
 def total_production(id_kl_min=0, productivity_fn=np.arange(n_kl),
                      labor_density=np.ones(n_kl),
                      kl_ratios=np.arange(1, n_kl + 1)):
-    if np.isscalar(id_kl_min):        
+    if np.isscalar(id_kl_min):
         return (productivity_fn[id_kl_min:-1] * labor_density[id_kl_min:-1]
                 * np.diff(kl_ratios[id_kl_min:])).sum()
     ltp = [(productivity_fn[i:-1] * ld[i:-1] * np.diff(kl_ratios[i:])).sum()

--- a/models/_model_Putty-Clay_AS69.py
+++ b/models/_model_Putty-Clay_AS69.py
@@ -29,30 +29,35 @@ _DESCRIPTION = """
     LINKTOARTICLE: Akerlof, G. A. and Stiglitz, J. E., 1969. 'Capital, Wages
         and Structural Unemployment', The Economic Journal, Vol. 79, No. 314
         http://www.jstor.org/stable/2230168
-    
     """
+
 _PRESETS = {}
 # ---------------------------
 # user-defined model
 # contains parameters and functions of various types
 
+
 def del_t_labor_density(I=0, I_distribution=np.ones(n_kl), delta=0,
-                        kl_ratios=np.arange(1, n_kl+1), itself=np.zeros(n_kl)):
+                        kl_ratios=np.arange(1, n_kl + 1), itself=np.zeros(n_kl)):
     return I * I_distribution / kl_ratios - delta * itself
+
 
 def minimum_profitable_kl_ratio_index(productivity_fn=np.arange(n_kl), w=0):
     return np.nonzero(productivity_fn >= w)[0][0]
+
 
 def profit_maximising_kl_ratio(productivity_fn=np.arange(n_kl), w=0,
                                kl_ratios=np.arange(1, n_kl + 1)):
     return kl_ratios[np.argmax((productivity_fn - w) / kl_ratios)]
 
-def lognormal_distribution(kl_optimum=1, kl_sigma=1, 
+
+def lognormal_distribution(kl_optimum=1, kl_sigma=1,
                            kl_ratios=np.arange(1, n_kl + 1)):
     gaussian = (np.exp(-0.5 * np.log(kl_ratios / kl_optimum)**2 / kl_sigma**2)
                 / kl_ratios)
     weighted_sum = (gaussian[:-1] * np.diff(kl_ratios)).sum()
     return np.pad(gaussian[:-1], (0, 1)) / weighted_sum
+
 
 def total_production(id_kl_min=0, productivity_fn=np.arange(n_kl),
                      labor_density=np.ones(n_kl),
@@ -64,6 +69,7 @@ def total_production(id_kl_min=0, productivity_fn=np.arange(n_kl),
            for i, ld in zip(id_kl_min.astype(int), labor_density)]
     return np.array(ltp)
 
+
 def total_labor(id_kl_min=0, labor_density=np.ones(n_kl),
                 kl_ratios=np.arange(1, n_kl + 1)):
     if np.isscalar(id_kl_min):
@@ -71,6 +77,7 @@ def total_labor(id_kl_min=0, labor_density=np.ones(n_kl),
     ltl = [(ld[i:-1] * np.diff(kl_ratios[i:])).sum()
            for i, ld in zip(id_kl_min.astype(int), labor_density)]
     return np.array(ltl)
+
 
 _DPARAM = {
     # ---------
@@ -84,7 +91,7 @@ _DPARAM = {
     's_w': 0,
     'kl_sigma': 0.1,
     'kl_ratios': kl_ratios,
-    
+
     # ---------
     # endogeneous functions
 
@@ -93,7 +100,7 @@ _DPARAM = {
         'func': lambda beta=0, itself=0: beta * itself,
         'initial': 6e6,
         'eqtype': 'ode',
-    },    
+    },
     'w': {
         'func': lambda L=0, N=1, itself=0, tau=1: (1e4 * L / (N - L) - itself) / tau,
         'initial': 5e4,
@@ -118,7 +125,7 @@ _DPARAM = {
     'kl_optimum': {
         'func': profit_maximising_kl_ratio,
         'eqtype': 'intermediary',
-    },        
+    },
     'I_distribution': {
         'func': lognormal_distribution,
         'eqtype': 'intermediary',

--- a/models/_model_Putty-Clay_AS69.py
+++ b/models/_model_Putty-Clay_AS69.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+"""
+Here we define the parameters and set of equation for a model of type 'Putty-Clay'
+
+All parameters can have value:
+    - None: set to the default value found in _def_fields.py
+    - scalar: int or float
+    - list or np.ndarray used for benchmarks
+    - function (callable): in that can it will be treated as a variable
+                            the function will be called at each time step
+
+"""
+
+
+import numpy as np
+
+n_kl = 100
+
+# ---------------------------
+# user-defined function order (optional)
+
+_FUNC_ORDER = None
+
+_DESCRIPTION = """
+    DESCRIPTION: Model with wages uniquely determined by unemployment, but with
+        technologies with varying capital-labor ratio, fixed at creation time
+    TYPICAL BEHAVIOUR: Decaying oscillations around a Solow point
+    LINKTOARTICLE: Akerlof, G. A. and Stiglitz, J. E., 1969. 'Capital, Wages
+        and Structural Unemployment', The Economic Journal, Vol. 79, No. 314
+        http://www.jstor.org/stable/2230168
+    
+    """
+_PRESETS = {}
+# ---------------------------
+# user-defined model
+# contains parameters and functions of various types
+
+def del_t_labor_density(I=0, I_distribution=np.ones(n_kl), delta=0,
+                        kl_ratios=np.arange(1, n_kl+1), itself=np.zeros(n_kl)):
+    return I * I_distribution / kl_ratios - delta * itself
+
+def minimum_profitable_kl_ratio_index(productivity_fn=np.arange(n_kl), W=0):
+    return np.nonzero(productivity_fn >= W)[0][0]
+
+def profit_maximising_kl_ratio(productivity_fn=np.arange(n_kl), W=0,
+                               kl_ratios=np.arange(1, n_kl + 1)):
+    return kl_ratios[np.argmax((productivity_fn - W) / kl_ratios)]
+
+def gaussian_distribution(kl_optimum=0, kl_sigma=1, 
+                          kl_ratios=np.arange(1, n_kl + 1)):
+    gaussian = np.exp(-0.5 * (kl_ratios - kl_optimum)**2 / kl_sigma**2)
+    return gaussian / (gaussian[:-1] * np.diff(kl_ratios)).sum()
+
+def total_production(id_kl_min=0, productivity_fn=np.arange(n_kl),
+                     labor_density=np.ones(n_kl),
+                     kl_ratios=np.arange(1, n_kl + 1)):
+    if type(id_kl_min) == np.ndarray:
+        p = [(productivity_fn[i:-1] * ld[i:-1] * np.diff(kl_ratios[i:])).sum()
+             for i, ld in zip(id_kl_min.astype(int), labor_density)]
+        return np.array(p)
+    return (productivity_fn[id_kl_min:-1] * labor_density[id_kl_min:-1]
+            * np.diff(kl_ratios[id_kl_min:])).sum()
+
+def total_labor(id_kl_min=0, labor_density=np.ones(n_kl),
+                kl_ratios=np.arange(1, n_kl + 1)):
+    if type(id_kl_min) == np.ndarray:
+        l = [(ld[i:-1] * np.diff(kl_ratios[i:])).sum()
+             for i, ld in zip(id_kl_min.astype(int), labor_density)]
+        return np.array(l)
+    return (labor_density[id_kl_min:-1] * np.diff(kl_ratios)).sum()
+
+_DPARAM = {
+    # ---------
+    # exogenous parameters
+    # can also have a time variation (just replace by a function of time)
+    # useful for studying the model's reaction to an exogenous shock
+    'delta': None,
+    'beta': None,
+    'tau': 0.1,
+    's_p': 1,
+    's_w': 0,
+    'kl_sigma': 0.1,
+    'kl_ratios': np.linspace(1, 100, n_kl),
+    
+    # ---------
+    # endogeneous functions
+
+    # differential equations (ode)
+    'N': {
+        'func': lambda beta=0, itself=0: beta * itself,
+        'initial': 1.,
+        'eqtype': 'ode',
+    },    
+    'W': {
+        'func': lambda L=0, N=1, itself=0, tau=1: (L / (N - L) - itself) / tau,
+        'initial': 0.,
+        'eqtype': 'ode',
+    },
+    # differential equations (pde)
+    'labor_density': {
+        'func': del_t_labor_density,
+        'initial': np.ones(n_kl),
+        'eqtype': 'pde',
+    },
+
+    # Intermediary functions (endogenous, computation intermediates)
+    'productivity_fn': {
+        'func': lambda kl_ratios=np.arange(n_kl): kl_ratios * np.log(1 + kl_ratios),
+        'eqtype': 'intermediary',
+    },
+    'id_kl_min': {
+        'func': minimum_profitable_kl_ratio_index,
+        'eqtype': 'intermediary',
+    },
+    'kl_optimum': {
+        'func': profit_maximising_kl_ratio,
+        'eqtype': 'intermediary',
+    },        
+    'I_distribution': {
+        'func': gaussian_distribution,
+        'eqtype': 'intermediary',
+    },
+    'GDP': {
+        'func': total_production,
+        'eqtype': 'intermediary',
+    },
+    'L': {
+        'func': total_labor,
+        'eqtype': 'intermediary',
+    },
+    'Pi': {
+        'func': lambda GDP=0, W=0, L=0: GDP - W * L,
+        'eqtype': 'intermediary',
+    },
+    'I': {
+        'func': lambda s_p=1, s_w=0, Pi=0, W=0, L=0: s_p * Pi + s_w * W * L,
+        'eqtype': 'intermediary',
+    },
+
+    # auxiliary, not used for computation but for interpretation
+    # => typically computed at the end after the computation
+    'lambda': {
+        'func': lambda L=0, N=1: L / N,
+        'eqtype': 'auxiliary',
+    },
+    'omega': {
+        'func': lambda W=0, L=0, GDP=1: W * L / GDP,
+        'eqtype': 'auxiliary',
+    }
+}

--- a/models/_model_Putty-Clay_AS69.py
+++ b/models/_model_Putty-Clay_AS69.py
@@ -40,12 +40,12 @@ def del_t_labor_density(I=0, I_distribution=np.ones(n_kl), delta=0,
                         kl_ratios=np.arange(1, n_kl+1), itself=np.zeros(n_kl)):
     return I * I_distribution / kl_ratios - delta * itself
 
-def minimum_profitable_kl_ratio_index(productivity_fn=np.arange(n_kl), W=0):
-    return np.nonzero(productivity_fn >= W)[0][0]
+def minimum_profitable_kl_ratio_index(productivity_fn=np.arange(n_kl), w=0):
+    return np.nonzero(productivity_fn >= w)[0][0]
 
-def profit_maximising_kl_ratio(productivity_fn=np.arange(n_kl), W=0,
+def profit_maximising_kl_ratio(productivity_fn=np.arange(n_kl), w=0,
                                kl_ratios=np.arange(1, n_kl + 1)):
-    return kl_ratios[np.argmax((productivity_fn - W) / kl_ratios)]
+    return kl_ratios[np.argmax((productivity_fn - w) / kl_ratios)]
 
 def lognormal_distribution(kl_optimum=1, kl_sigma=1, 
                            kl_ratios=np.arange(1, n_kl + 1)):
@@ -94,7 +94,7 @@ _DPARAM = {
         'initial': 6e6,
         'eqtype': 'ode',
     },    
-    'W': {
+    'w': {
         'func': lambda L=0, N=1, itself=0, tau=1: (1e4 * L / (N - L) - itself) / tau,
         'initial': 5e4,
         'eqtype': 'ode',
@@ -132,11 +132,11 @@ _DPARAM = {
         'eqtype': 'intermediary',
     },
     'Pi': {
-        'func': lambda GDP=0, W=0, L=0: GDP - W * L,
+        'func': lambda GDP=0, w=0, L=0: GDP - w * L,
         'eqtype': 'intermediary',
     },
     'I': {
-        'func': lambda s_p=1, s_w=0, Pi=0, W=0, L=0: s_p * Pi + s_w * W * L,
+        'func': lambda s_p=1, s_w=0, Pi=0, w=0, L=0: s_p * Pi + s_w * w * L,
         'eqtype': 'intermediary',
     },
 
@@ -147,7 +147,7 @@ _DPARAM = {
         'eqtype': 'auxiliary',
     },
     'omega': {
-        'func': lambda W=0, L=0, GDP=1: W * L / GDP,
+        'func': lambda w=0, L=0, GDP=1: w * L / GDP,
         'eqtype': 'auxiliary',
     }
 }

--- a/utilities/_class_checks.py
+++ b/utilities/_class_checks.py
@@ -278,7 +278,7 @@ def _check_func(dparam=None, func_order=None, method=None):
                 dfail[k0] = "pde equation needs an 'initial' value array"
                 continue
             elif v0.get('initial').dtype not in _LTYPES:
-                dfail[k0] = "'initial' values must be numeric"                
+                dfail[k0] = "'initial' values must be numeric"
                 continue
 
         # Check is there is a circular dependency
@@ -348,7 +348,7 @@ def _check_func(dparam=None, func_order=None, method=None):
             kargs = []
             print(f"Error with parameter {k0}: {err}")
             print(dparam[k0])
-                
+
         argsf = [kk for kk in kargs if kk in lfi]
         dparam[k0]['args'] = {
             'param': [kk for kk in kargs if kk not in lfi],
@@ -400,7 +400,7 @@ def _check_func(dparam=None, func_order=None, method=None):
             assert dparam[k0].get('source_exp') is None
             # Read the function definition (or its first line if a lambda fn)
             source = inspect.getsource(dparam[k0]['func'])
-            
+
             if source[:4] == "def ":
                 # Remove "def {func}(" from the string
                 source = source[source.index('(') + 1:]
@@ -408,13 +408,13 @@ def _check_func(dparam=None, func_order=None, method=None):
                 n_braces = (np.cumsum(np.array([c == '[' for c in source]))
                             - np.cumsum(np.array([c == ']' for c in source])))
                 id_sep = (np.logical_not(n_braces)
-                          & np.array([c == ':' for c in source])).nonzero()[0]    
+                          & np.array([c == ':' for c in source])).nonzero()[0]
                 if id_sep.size == 0:
                     msg = (
                         f"The source function for {k0} is non-valid\n"
                         "It should have a ':' to end the function header\n"
                         f"Provided:\n{source}"
-                        )
+                    )
                     raise Exception(msg)
                 # Separate parameters, before "):", and expression, after
                 kargs, exp = source[:id_sep[0] - 1], source[id_sep[0] + 1:]
@@ -426,32 +426,32 @@ def _check_func(dparam=None, func_order=None, method=None):
                         "lambda function with non-lambda function arguments, "
                         "ending with ',\n'"
                         f"Provided source:\n{source}"
-                        )
-                    raise Exception(msg)                
+                    )
+                    raise Exception(msg)
                 source = source.strip().replace(',\n', '')
                 source = source[source.index('lambda') + len('lambda'):]
-                # Identify the index of the colon that ends the parameter list            
+                # Identify the index of the colon that ends the parameter list
                 n_braces = (np.cumsum(np.array([c == '[' for c in source]))
                             - np.cumsum(np.array([c == ']' for c in source])))
                 id_sep = (np.logical_not(n_braces)
-                          & np.array([c == ':' for c in source])).nonzero()[0]    
+                          & np.array([c == ':' for c in source])).nonzero()[0]
                 if id_sep.size != 1:
                     msg = (
                         f"The source function for {k0} is non-valid\n"
                         "Outside slices, it should have a single ':'\n"
                         f"Provided:\n{source}"
-                        )
+                    )
                     raise Exception(msg)
                 # Separate parameters, before ":", and expression, after
                 kargs, exp = source[:id_sep[0]], source[id_sep[0] + 1:]
                 exp = exp.strip()
-            # Identify the indices of commas that separate the parameter list            
+            # Identify the indices of commas that separate the parameter list
             n_parens = (np.cumsum(np.array([c == '(' for c in kargs]))
                         - np.cumsum(np.array([c == ')' for c in kargs])))
             id_sep = list((np.logical_not(n_parens)
                            & np.array([c == ',' for c in kargs])).nonzero()[0])
             # Separate parameters
-            kargs = [kargs[i+1:j].strip()
+            kargs = [kargs[i + 1:j].strip()
                      for (i, j) in zip([-1] + id_sep, id_sep + [None])]
             if not all(['=' in kk for kk in kargs]):
                 msg = (

--- a/utilities/_class_checks.py
+++ b/utilities/_class_checks.py
@@ -402,8 +402,7 @@ def _check_func(dparam=None, func_order=None, method=None):
             source = inspect.getsource(dparam[k0]['func'])
             
             if source[:4] == "def ":
-                # Remove newlines and "def {func}(" from the string
-                source = source.strip().replace('\n', '')
+                # Remove "def {func}(" from the string
                 source = source[source.index('(') + 1:]
                 # Identify the index of the colon that ends the function header
                 n_braces = (np.cumsum(np.array([c == '[' for c in source]))
@@ -445,7 +444,7 @@ def _check_func(dparam=None, func_order=None, method=None):
                     raise Exception(msg)
                 # Separate parameters, before ":", and expression, after
                 kargs, exp = source[:id_sep[0]], source[id_sep[0] + 1:]
-            exp = exp.strip()
+                exp = exp.strip()
             # Identify the indices of commas that separate the parameter list            
             n_parens = (np.cumsum(np.array([c == '(' for c in kargs]))
                         - np.cumsum(np.array([c == ')' for c in kargs])))

--- a/utilities/_class_checks.py
+++ b/utilities/_class_checks.py
@@ -187,13 +187,13 @@ def check_dparam(dparam=None, func_order=None, method=None, model=None):
                 + models.get_available_models(returnas=str, verb=False)
             )
             raise Exception(msg)
-        model = {dparam: models._DMODEL[dparam]['file']}
+        model = {'name': dparam, 'file': models._DMODEL[dparam]['file']}
         if func_order is None:
             func_order = models._DMODEL[dparam]['func_order']
         dparam = copy.deepcopy(models._DMODEL[dparam]['dparam'])
     else:
         if model is None:
-            model = {"custom": ''}
+            model = {'name': "custom", 'file': ""}
 
     # check conformity
     dparam = _check_dparam(dparam)

--- a/utilities/_class_utility.py
+++ b/utilities/_class_utility.py
@@ -94,7 +94,7 @@ def _get_dict_subset(
         for ii, k0 in enumerate(lk):
             for ss in lprint[1:]:
                 if ss == 'value':
-                    if indict[k0].get('func') is not None:
+                    if isinstance(indict[k0].get('value'), np.ndarray):
                         ar0[ii].append(str(indict[k0]['value'].shape))
                     else:
                         ar0[ii].append(str(indict[k0]['value']))
@@ -106,6 +106,7 @@ def _get_dict_subset(
             _utils._get_summary(
                 lar=[ar0],
                 lcol=[col0],
+                lps=['' ] * len(lprint),
                 verb=True,
                 returnas=False,
             )

--- a/utilities/_class_utility.py
+++ b/utilities/_class_utility.py
@@ -30,8 +30,9 @@ def _get_dict_subset(
     """ Return a copy of the input parameters dict
 
     Return as:
+        - list: list of keys
         - dict: dict
-        - 'DataGFrame': a pandas DataFrame
+        - 'DataFrame': a pandas DataFrame
         - np.ndarray: a dict of np.ndarrays
         - False: return nothing (useful of verb=True)
 

--- a/utilities/_class_utility.py
+++ b/utilities/_class_utility.py
@@ -157,7 +157,7 @@ def _dict_equal(dict1, dict2, dd=None):
         msg = None
 
         # check type
-        if type(v0) != type(dict2[k0]):
+        if isinstance(v0, type(dict2[k0])):
             msg = f"different type ({type(v0)} vs {type(dict2[k0])})"
             dfail[key] = msg
             continue

--- a/utilities/_saveload.py
+++ b/utilities/_saveload.py
@@ -160,7 +160,7 @@ def save(
     # --------------
     # Make full name
     dinclude = {
-        'model': list(obj.model.keys())[0].replace('_', '-').replace(' ', '-'),
+        'model': obj.model['name'].replace('_', '-').replace(' ', '-'),
         'solver': obj.dmisc['solver'],
         'name': name,
         'user': getpass.getuser(),

--- a/utilities/_solvers.py
+++ b/utilities/_solvers.py
@@ -40,19 +40,19 @@ def _eRK4_homemade(
                 timewait=timewait, end=end, flush=flush,
                 t0=t0,
             )
-            
+
         # compute ode variables from ii-1, using solver
         for k0 in lode + lpde:
             kwdargs = {
-                k1: v1[ii-1, :] for k1, v1 in dargs[k0].items()
+                k1: v1[ii - 1, :] for k1, v1 in dargs[k0].items()
             }
 
             dparam[k0]['value'][ii] = (
-                dparam[k0]['value'][ii-1]
+                dparam[k0]['value'][ii - 1]
                 + _rk4(
                     dparam=dparam,
                     k0=k0,
-                    y=dparam[k0]['value'][ii-1],
+                    y=dparam[k0]['value'][ii - 1],
                     kwdargs=kwdargs,
                 )
             )

--- a/utilities/_solvers.py
+++ b/utilities/_solvers.py
@@ -104,10 +104,6 @@ def _rk4(dparam=None, k0=None, y=None, kwdargs=None):
         dy2 = dparam[k0]['func'](**kwdargs)
         dy3 = dparam[k0]['func'](**kwdargs)
         dy4 = dparam[k0]['func'](**kwdargs)
-    # DEBUG
-    if k0 == 'W':
-        print(", ".join([f"{k}: {v}" for k, v in kwdargs.items()]))
-        print(f"W: {y}, W': {dy1}")
     return (dy1 + 2*dy2 + 2*dy3 + dy4) * dparam['dt']['value']/6.
 
 

--- a/utilities/_solvers.py
+++ b/utilities/_solvers.py
@@ -17,6 +17,7 @@ from . import _class_checks
 def _eRK4_homemade(
     dparam=None,
     lode=None,
+    lpde=None,
     linter=None,
     laux=None,
     dargs=None,
@@ -39,18 +40,19 @@ def _eRK4_homemade(
                 timewait=timewait, end=end, flush=flush,
                 t0=t0,
             )
+            
         # compute ode variables from ii-1, using solver
-        for k0 in lode:
+        for k0 in lode + lpde:
             kwdargs = {
                 k1: v1[ii-1, :] for k1, v1 in dargs[k0].items()
             }
 
-            dparam[k0]['value'][ii, :] = (
-                dparam[k0]['value'][ii-1, :]
+            dparam[k0]['value'][ii] = (
+                dparam[k0]['value'][ii-1]
                 + _rk4(
                     dparam=dparam,
                     k0=k0,
-                    y=dparam[k0]['value'][ii-1, :],
+                    y=dparam[k0]['value'][ii-1],
                     kwdargs=kwdargs,
                 )
             )
@@ -102,6 +104,10 @@ def _rk4(dparam=None, k0=None, y=None, kwdargs=None):
         dy2 = dparam[k0]['func'](**kwdargs)
         dy3 = dparam[k0]['func'](**kwdargs)
         dy4 = dparam[k0]['func'](**kwdargs)
+    # DEBUG
+    if k0 == 'W':
+        print(", ".join([f"{k}: {v}" for k, v in kwdargs.items()]))
+        print(f"W: {y}, W': {dy1}")
     return (dy1 + 2*dy2 + 2*dy3 + dy4) * dparam['dt']['value']/6.
 
 

--- a/utilities/_utils.py
+++ b/utilities/_utils.py
@@ -52,6 +52,7 @@ def _getcharray(ar, col=None, sep='  ', line='-', just='l', msg=True):
 def _get_summary(
     lar=None,       # list of data arrays
     lcol=None,      # list of column headers
+    lps=None,
     sep='  ',
     line='-',
     just='l',
@@ -70,8 +71,8 @@ def _get_summary(
     # Out
     if verb or returnas in [True, str]:
         lmsg = [
-            _getcharray(ar, col, sep=sep, line=line, just=just)
-            for ar, col in zip(*[lar, lcol])
+            _getcharray(ar, col, sep=sep, line=line, just=just) + ps
+            for ar, col, ps in zip(*[lar, lcol, lps])
         ]
         if verb:
             msg = table_sep.join(lmsg)

--- a/utilities/_utils.py
+++ b/utilities/_utils.py
@@ -52,7 +52,7 @@ def _getcharray(ar, col=None, sep='  ', line='-', just='l', msg=True):
 def _get_summary(
     lar=None,       # list of data arrays
     lcol=None,      # list of column headers
-    lps=None,
+    lps=None,       # list of postscripts
     sep='  ',
     line='-',
     just='l',


### PR DESCRIPTION
Added a model corresponding to a Goodwin-adjacent model, with a putty-clay production function, from Akerlof and Stiglitz (1969), and changed the code base to support this model. In the paper's model, investors select from technologies with different capital-labor ratios, to maximise profits based on current wages, but the capital-labor ratio is fixed at the point of investment. Consequently, potential employment is distributed at any time over machines of varying capital-labor ratio, with the distribution evolving as a partial differential equation. This model does not yet support multiple parallel systems.

To implement the model, support's been added in `set_dparam`, `reset`, `get_variables_compact`, `get_summary`, and `class_checks` for:
- `np.ndarray` parameters and variables
- multi-line non-lambda `'func'` definitions
- a `'pde`' equation type
These features are not yet supported in analysis and plotting code.

`def_fields` has been updated with the new model's variables and parameters and with corrected dimensions and units (fixing issue #85).

Ref:
- Akerlof, G. A. and Stiglitz, J. E., 1969. 'Capital, Wages and Structural Unemployment', The Economic Journal, Vol. 79, No. 314 (http://www.jstor.org/stable/2230168)